### PR TITLE
Support for UBL invoices in EN16931 format, version 1.3.1.

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -112,12 +112,30 @@ class Address implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
-        $writer->write([
-            Schema::CBC . 'StreetName' => $this->streetName,
-            Schema::CBC . 'BuildingNumber' => $this->buildingNumber,
-            Schema::CBC . 'CityName' => $this->cityName,
-            Schema::CBC . 'PostalZone' => $this->postalZone,
-            Schema::CAC . 'Country' => $this->country,
-        ]);
+        if ($this->streetName != null) {
+            $writer->write([
+                Schema::CBC . 'StreetName' => $this->streetName
+            ]);
+        }
+        if ($this->buildingNumber != null) {
+            $writer->write([
+                Schema::CBC . 'BuildingNumber' => $this->buildingNumber
+            ]);
+        }
+        if ($this->cityName != null) {
+            $writer->write([
+                Schema::CBC . 'CityName' => $this->cityName,
+            ]);
+        }
+        if ($this->postalZone != null) {
+            $writer->write([
+                Schema::CBC . 'PostalZone' => $this->postalZone,
+            ]);
+        }
+        if ($this->country != null) {
+            $writer->write([
+                Schema::CAC . 'Country' => $this->country,
+            ]);
+        }
     }
 }

--- a/src/ClassifiedTaxCategory.php
+++ b/src/ClassifiedTaxCategory.php
@@ -11,6 +11,10 @@ class ClassifiedTaxCategory implements XmlSerializable
     private $name;
     private $percent;
     private $taxScheme;
+    private $taxExemptionReason;
+    private $taxExemptionReasonCode;
+    private $schemeID;
+    private $schemeName;
 
     public const UNCL5305 = 'UNCL5305';
 
@@ -101,6 +105,26 @@ class ClassifiedTaxCategory implements XmlSerializable
     }
 
     /**
+     * @param mixed $id
+     * @return ClassifiedTaxCategory
+     */
+    public function setSchemeID($id)
+    {
+        $this->schemeID = $id;
+        return $this;
+    }
+
+    /**
+     * @param mixed $name
+     * @return ClassifiedTaxCategory
+     */
+    public function setSchemeName($name)
+    {
+        $this->schemeName = $name;
+        return $this;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @throws InvalidArgumentException An error with information about required data that is missing to write the XML
@@ -110,10 +134,6 @@ class ClassifiedTaxCategory implements XmlSerializable
     {
         if ($this->getId() === null) {
             throw new \InvalidArgumentException('Missing taxcategory id');
-        }
-
-        if ($this->getName() === null) {
-            throw new \InvalidArgumentException('Missing taxcategory name');
         }
 
         if ($this->getPercent() === null) {
@@ -130,24 +150,35 @@ class ClassifiedTaxCategory implements XmlSerializable
     public function xmlSerialize(Writer $writer)
     {
         $this->validate();
-
+        $schemeAttributes = array();
+        if ($this->schemeID != null) {
+            $schemeAttributes['schemeID'] = $this->schemeID;
+        }
+        if ($this->schemeName != null) {
+            $schemeAttributes['schemeName'] = $this->schemeName;
+        }
         $writer->write([
             [
                 'name' => Schema::CBC . 'ID',
                 'value' => $this->getId(),
-                'attributes' => [
-                    'schemeID' => ClassifiedTaxCategory::UNCL5305,
-                    'schemeName' => 'Duty or tax or fee category'
-                ]
+                'attributes' => $schemeAttributes
+                
             ],
-            Schema::CBC . 'Name' => $this->name,
             Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
         ]);
 
-        $writer->write([
-            Schema::CBC . 'TaxExemptionReasonCode' => null,
-            Schema::CBC . 'TaxExemptionReason' => null,
-        ]);
+        if ($this->name != null) {
+            $writer->write([
+                Schema::CBC . 'Name' => $this->name,
+            ]);
+        }
+
+        if ($this->taxExemptionReasonCode != null) {
+            $writer->write([
+                Schema::CBC . 'TaxExemptionReasonCode' => $this->taxExemptionReasonCode,
+                Schema::CBC . 'TaxExemptionReason' => $this->taxExemptionReason,
+            ]);
+        }
 
         if ($this->taxScheme != null) {
             $writer->write([Schema::CAC . 'TaxScheme' => $this->taxScheme]);

--- a/src/FinancialInstitutionBranch.php
+++ b/src/FinancialInstitutionBranch.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+use DateTime;
+
+class FinancialInstitutionBranch implements XmlSerializable
+{
+    private $id;
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     * @return FinancialInstitutionBranch
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    
+
+    public function xmlSerialize(Writer $writer)
+    {
+        $writer->write([
+            Schema::CBC . 'ID' => $this->id
+        ]);
+    }
+}

--- a/src/FinancialInstitutionBranch.php
+++ b/src/FinancialInstitutionBranch.php
@@ -5,8 +5,6 @@ namespace NumNum\UBL;
 use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
-use DateTime;
-
 class FinancialInstitutionBranch implements XmlSerializable
 {
     private $id;
@@ -28,8 +26,6 @@ class FinancialInstitutionBranch implements XmlSerializable
         $this->id = $id;
         return $this;
     }
-
-    
 
     public function xmlSerialize(Writer $writer)
     {

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -440,7 +440,7 @@ class Invoice implements XmlSerializable
                 Schema::CBC . 'CopyIndicator' => $this->copyIndicator ? 'true' : 'false'
             ]);
         }
-        
+
         $writer->write([
             Schema::CBC . 'IssueDate' => $this->issueDate->format('Y-m-d'),
             [
@@ -448,8 +448,6 @@ class Invoice implements XmlSerializable
                 'value' => $this->invoiceTypeCode
             ]
         ]);
-
-        
 
         if ($this->taxPointDate != null) {
             $writer->write([
@@ -472,7 +470,7 @@ class Invoice implements XmlSerializable
                 Schema::CBC . 'AccountingCostCode' => $this->accountingCostCode
             ]);
         }
-        
+
         if ($this->buyerReference != null) {
             $writer->write([
                 Schema::CBC . 'BuyerReference' => $this->buyerReference,
@@ -486,7 +484,7 @@ class Invoice implements XmlSerializable
             ]);
         }
 
-        
+
         $writer->write([
             Schema::CAC . 'AccountingSupplierParty' => [Schema::CAC . "Party" => $this->accountingSupplierParty],
             Schema::CAC . 'AccountingCustomerParty' => [Schema::CAC . "Party" => $this->accountingCustomerParty],

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -25,6 +25,8 @@ class Invoice implements XmlSerializable
     private $allowanceCharges;
     private $additionalDocumentReference;
     private $documentCurrencyCode = 'EUR';
+    private $buyerReference;
+
 
     /**
      * @return string
@@ -340,6 +342,24 @@ class Invoice implements XmlSerializable
     }
 
     /**
+     * @param string $buyerReference
+     * @return Invoice
+     */
+    public function setBuyerReference(string $buyerReference)
+    {
+        $this->buyerReference = $buyerReference;
+        return $this;
+    }
+
+      /**
+     * @return string buyerReference
+     */
+    public function getBuyerReference()
+    {
+        return $this->buyerReference;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @return void
@@ -426,6 +446,13 @@ class Invoice implements XmlSerializable
         $writer->write([
             Schema::CBC . 'DocumentCurrencyCode' => $this->documentCurrencyCode,
         ]);
+
+        if ($this->buyerReference != null) {
+            $writer->write([
+                Schema::CBC . 'BuyerReference' => $this->buyerReference,
+                Schema::CAC . 'OrderReference' => [Schema::CBC . "ID" => $this->buyerReference]
+            ]);
+        }
 
         if ($this->additionalDocumentReference != null) {
             $writer->write([

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -26,6 +26,8 @@ class Invoice implements XmlSerializable
     private $additionalDocumentReference;
     private $documentCurrencyCode = 'EUR';
     private $buyerReference;
+    private $accountingCostCode;
+
 
 
     /**
@@ -360,6 +362,24 @@ class Invoice implements XmlSerializable
     }
 
     /**
+     * @return mixed
+     */
+    public function getAccountingCostCode()
+    {
+        return $this->accountingCostCode;
+    }
+
+    /**
+     * @param mixed $accountingCostCode
+     * @return InvoiceLine
+     */
+    public function setAccountingCostCode($accountingCostCode)
+    {
+        $this->accountingCostCode = $accountingCostCode;
+        return $this;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @return void
@@ -447,6 +467,12 @@ class Invoice implements XmlSerializable
             Schema::CBC . 'DocumentCurrencyCode' => $this->documentCurrencyCode,
         ]);
 
+        if ($this->accountingCostCode !== null) {
+            $writer->write([
+                Schema::CBC . 'AccountingCostCode' => $this->accountingCostCode
+            ]);
+        }
+        
         if ($this->buyerReference != null) {
             $writer->write([
                 Schema::CBC . 'BuyerReference' => $this->buyerReference,
@@ -460,6 +486,7 @@ class Invoice implements XmlSerializable
             ]);
         }
 
+        
         $writer->write([
             Schema::CAC . 'AccountingSupplierParty' => [Schema::CAC . "Party" => $this->accountingSupplierParty],
             Schema::CAC . 'AccountingCustomerParty' => [Schema::CAC . "Party" => $this->accountingCustomerParty],

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -10,7 +10,7 @@ class Invoice implements XmlSerializable
     private $UBLVersionID = '2.1';
     private $customizationID = '1.0';
     private $id;
-    private $copyIndicator = false;
+    private $copyIndicator;
     private $issueDate;
     private $invoiceTypeCode = InvoiceTypeCode::INVOICE;
     private $taxPointDate;
@@ -63,6 +63,17 @@ class Invoice implements XmlSerializable
         return $this;
     }
 
+    /**
+     * @param mixed $customizationID
+     * @return Invoice
+     */
+    public function setCustomizationID($id)
+    {
+        $this->customizationID = $id;
+        return $this;
+    }
+
+    /**
     /**
      * @return bool
      */
@@ -381,14 +392,24 @@ class Invoice implements XmlSerializable
         $writer->write([
             Schema::CBC . 'UBLVersionID' => $this->UBLVersionID,
             Schema::CBC . 'CustomizationID' => $this->customizationID,
-            Schema::CBC . 'ID' => $this->id,
-            Schema::CBC . 'CopyIndicator' => $this->copyIndicator ? 'true' : 'false',
+            Schema::CBC . 'ID' => $this->id
+        ]);
+
+        if ($this->copyIndicator !== null) {
+            $writer->write([
+                Schema::CBC . 'CopyIndicator' => $this->copyIndicator ? 'true' : 'false'
+            ]);
+        }
+        
+        $writer->write([
             Schema::CBC . 'IssueDate' => $this->issueDate->format('Y-m-d'),
             [
                 'name' => Schema::CBC . 'InvoiceTypeCode',
                 'value' => $this->invoiceTypeCode
             ]
         ]);
+
+        
 
         if ($this->taxPointDate != null) {
             $writer->write([

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -191,8 +191,15 @@ class InvoiceLine implements XmlSerializable
                 'attributes' => [
                     'currencyID' => Generator::$currencyID
                 ]
-            ],
-            Schema::CAC . 'TaxTotal' => $this->taxTotal,
+            ]
+        ]);
+
+        if ($this->taxTotal !== null) {
+            $writer->write([
+                Schema::CAC . 'TaxTotal' => $this->taxTotal
+            ]);
+        }
+        $writer->write([
             Schema::CAC . 'Item' => $this->item,
         ]);
 

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -15,6 +15,7 @@ class InvoiceLine implements XmlSerializable
     private $note;
     private $item;
     private $price;
+    private $accountingCostCode;
 
     /**
      * @return mixed
@@ -161,6 +162,24 @@ class InvoiceLine implements XmlSerializable
     }
 
     /**
+     * @return mixed
+     */
+    public function getAccountingCostCode()
+    {
+        return $this->accountingCostCode;
+    }
+
+    /**
+     * @param mixed $accountingCostCode
+     * @return InvoiceLine
+     */
+    public function setAccountingCostCode($accountingCostCode)
+    {
+        $this->accountingCostCode = $accountingCostCode;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      * @param Writer $writer
      * @return void
@@ -194,6 +213,11 @@ class InvoiceLine implements XmlSerializable
             ]
         ]);
 
+        if ($this->accountingCostCode !== null) {
+            $writer->write([
+                Schema::CBC . 'AccountingCostCode' => $this->accountingCostCode
+            ]);
+        }
         if ($this->taxTotal !== null) {
             $writer->write([
                 Schema::CAC . 'TaxTotal' => $this->taxTotal

--- a/src/Party.php
+++ b/src/Party.php
@@ -12,6 +12,8 @@ class Party implements XmlSerializable
     private $physicalLocation;
     private $contact;
     private $companyId;
+    private $taxCompanyId;
+    private $taxCompanyName;
     private $taxScheme;
     private $legalEntity;
 
@@ -67,6 +69,21 @@ class Party implements XmlSerializable
         $this->companyId = $companyId;
     }
 
+    /**
+     * @param string $taxCompanyId
+     */
+    public function setTaxCompanyId($companyId)
+    {
+        $this->taxCompanyId = $companyId;
+    }
+
+    /**
+     * @param string $taxCompanyName
+     */
+    public function setTaxCompanyName($companyName)
+    {
+        $this->taxCompanyName = $companyName;
+    }
     /**
      * @param TaxScheme $taxScheme.
      * @return mixed
@@ -160,18 +177,28 @@ class Party implements XmlSerializable
         }
 
         if ($this->taxScheme) {
+            $partyTaxScheme = array();
+            if ($this->taxCompanyName != null) {
+                $partyTaxScheme[Schema::CBC . 'RegistrationName'] = $this->taxCompanyName;
+            }
+            if ($this->taxCompanyId != null) {
+                $partyTaxScheme[Schema::CBC . 'CompanyID'] = $this->taxCompanyId;
+            }
+            $partyTaxScheme[Schema::CAC . 'TaxScheme'] = $this->taxScheme;
             $writer->write([
-                Schema::CAC . 'PartyTaxScheme' => [
-                    Schema::CBC . 'RegistrationName' => $this->name,
-                    Schema::CBC . 'CompanyID' => $this->companyId,
-                    Schema::CAC . 'TaxScheme' => $this->taxScheme
-                ]
+                Schema::CAC . 'PartyTaxScheme' => $partyTaxScheme
             ]);
         }
 
         if ($this->contact) {
             $writer->write([
                 Schema::CAC . 'Contact' => $this->contact
+            ]);
+        }
+
+        if ($this->legalEntity) {
+            $writer->write([
+                Schema::CAC . 'PartyLegalEntity' => $this->legalEntity
             ]);
         }
     }

--- a/src/PayeeFinancialAccount.php
+++ b/src/PayeeFinancialAccount.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+use DateTime;
+
+class PayeeFinancialAccount implements XmlSerializable
+{
+    private $id;
+    private $name;
+    private $financialInstitutionBranch;
+
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     * @return PayeeFinancialAccount
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     * @return PayeeFinancialAccount
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+       /**
+     * @return mixed
+     */
+    public function getFinancialInstitutionBranch()
+    {
+        return $this->financialInstitutionBranch;
+    }
+
+    /**
+     * @param mixed $financialInstitutionBranch
+     * @return PayeeFinancialAccount
+     */
+    public function setFinancialInstitutionBranch($financialInstitutionBranch)
+    {
+        $this->financialInstitutionBranch = $financialInstitutionBranch;
+        return $this;
+    }
+    
+
+    public function xmlSerialize(Writer $writer)
+    {
+        $writer->write([
+            'name' => Schema::CBC . 'ID',
+            'value' => $this->id,
+            'attributes' => [
+                //'schemeID' => 'IBAN'
+            ]
+        ]);
+
+        if ($this->getName() !== null) {
+            $writer->write([
+                Schema::CBC . 'Name' => $this->getName()
+            ]);
+        }
+
+        if ($this->getFinancialInstitutionBranch() !== null) {
+            $writer->write([
+                Schema::CAC . 'FinancialInstitutionBranch' => $this->getFinancialInstitutionBranch()
+            ]);
+        }
+    }
+}

--- a/src/PayeeFinancialAccount.php
+++ b/src/PayeeFinancialAccount.php
@@ -5,8 +5,6 @@ namespace NumNum\UBL;
 use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
-use DateTime;
-
 class PayeeFinancialAccount implements XmlSerializable
 {
     private $id;
@@ -67,7 +65,7 @@ class PayeeFinancialAccount implements XmlSerializable
         $this->financialInstitutionBranch = $financialInstitutionBranch;
         return $this;
     }
-    
+
 
     public function xmlSerialize(Writer $writer)
     {

--- a/src/PaymentMeans.php
+++ b/src/PaymentMeans.php
@@ -10,8 +10,14 @@ use DateTime;
 class PaymentMeans implements XmlSerializable
 {
     private $paymentMeansCode = 1;
+    private $paymentMeansCodeAttributes = [
+        'listID' => 'UN/ECE 4461',
+        'listName' => 'Payment Means',
+        'listURI' => 'http://docs.oasis-open.org/ubl/os-UBL-2.0-update/cl/gc/default/PaymentMeansCode-2.0.gc'];
     private $paymentDueDate;
     private $instructionId;
+    private $paymentId;
+    private $payeeFinancialAccount;
 
     /**
      * @return mixed
@@ -25,9 +31,12 @@ class PaymentMeans implements XmlSerializable
      * @param mixed $paymentMeansCode
      * @return PaymentMeans
      */
-    public function setPaymentMeansCode($paymentMeansCode)
+    public function setPaymentMeansCode($paymentMeansCode, $attributes = null)
     {
         $this->paymentMeansCode = $paymentMeansCode;
+        if (isset($attributes)) {
+            $this->paymentMeansCodeAttributes = $attributes;
+        }
         return $this;
     }
 
@@ -67,16 +76,48 @@ class PaymentMeans implements XmlSerializable
         return $this;
     }
 
+    /**
+     * @return mixed
+     */
+    public function getPaymentId()
+    {
+        return $this->paymentId;
+    }
+
+    /**
+     * @param mixed $paymentId
+     * @return PaymentMeans
+     */
+    public function setPaymentId($paymentId)
+    {
+        $this->paymentId = $paymentId;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayeeFinancialAccount()
+    {
+        return $this->payeeFinancialAccount;
+    }
+
+    /**
+     * @param mixed $payeeFinancialAccount
+     * @return PaymentMeans
+     */
+    public function setPayeeFinancialAccount($payeeFinancialAccount)
+    {
+        $this->payeeFinancialAccount = $payeeFinancialAccount;
+        return $this;
+    }
+
     public function xmlSerialize(Writer $writer)
     {
         $writer->write([
             'name' => Schema::CBC . 'PaymentMeansCode',
             'value' => $this->paymentMeansCode,
-            'attributes' => [
-                'listID' => 'UN/ECE 4461',
-                'listName' => 'Payment Means',
-                'listURI' => 'http://docs.oasis-open.org/ubl/os-UBL-2.0-update/cl/gc/default/PaymentMeansCode-2.0.gc'
-            ]
+            'attributes' => $this->paymentMeansCodeAttributes
         ]);
 
         if ($this->getPaymentDueDate() !== null) {
@@ -88,6 +129,18 @@ class PaymentMeans implements XmlSerializable
         if ($this->getInstructionId() !== null) {
             $writer->write([
                 Schema::CBC . 'InstructionID' => $this->getInstructionId()
+            ]);
+        }
+
+        if ($this->getPaymentId() !== null) {
+            $writer->write([
+                Schema::CBC . 'PaymentID' => $this->getPaymentId()
+            ]);
+        }
+
+        if ($this->getpayeeFinancialAccount() !== null) {
+            $writer->write([
+                Schema::CAC . 'PayeeFinancialAccount' => $this->getPayeeFinancialAccount()
             ]);
         }
     }

--- a/src/TaxCategory.php
+++ b/src/TaxCategory.php
@@ -109,6 +109,42 @@ class TaxCategory implements XmlSerializable
     }
 
     /**
+     * @return mixed
+     */
+    public function getTaxExemptionReason()
+    {
+        return $this->taxExemptionReason;
+    }
+
+    /**
+     * @param mixed $taxExemptionReason
+     * @return TaxCategory
+     */
+    public function setTaxExemptionReason($taxExemptionReason)
+    {
+        $this->taxExemptionReason = $taxExemptionReason;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTaxExemptionReasonCode()
+    {
+        return $this->taxExemptionReasonCode;
+    }
+
+    /**
+     * @param mixed $taxExemptionReason
+     * @return TaxCategory
+     */
+    public function setTaxExemptionReasonCode($taxExemptionReasonCode)
+    {
+        $this->taxExemptionReasonCode = $taxExemptionReasonCode;
+        return $this;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @throws InvalidArgumentException An error with information about required data that is missing to write the XML
@@ -155,6 +191,11 @@ class TaxCategory implements XmlSerializable
         if ($this->taxExemptionReasonCode != null) {
             $writer->write([
                 Schema::CBC . 'TaxExemptionReasonCode' => $this->taxExemptionReasonCode,
+            ]);
+        }
+
+        if ($this->taxExemptionReason != null) {
+            $writer->write([
                 Schema::CBC . 'TaxExemptionReason' => $this->taxExemptionReason,
             ]);
         }

--- a/src/TaxCategory.php
+++ b/src/TaxCategory.php
@@ -8,9 +8,14 @@ use Sabre\Xml\XmlSerializable;
 class TaxCategory implements XmlSerializable
 {
     private $id;
+    private $idAttributes = [
+        'schemeID' => TaxCategory::UNCL5305,
+        'schemeName' => 'Duty or tax or fee category'];
     private $name;
     private $percent;
     private $taxScheme;
+    private $taxExemptionReason;
+    private $taxExemptionReasonCode;
 
     public const UNCL5305 = 'UNCL5305';
 
@@ -40,9 +45,12 @@ class TaxCategory implements XmlSerializable
      * @param mixed $id
      * @return TaxCategory
      */
-    public function setId($id)
+    public function setId($id, $attributes = null)
     {
         $this->id = $id;
+        if (isset($attributes)) {
+            $this->idAttributes = $attributes;
+        }
         return $this;
     }
 
@@ -112,10 +120,6 @@ class TaxCategory implements XmlSerializable
             throw new \InvalidArgumentException('Missing taxcategory id');
         }
 
-        if ($this->getName() === null) {
-            throw new \InvalidArgumentException('Missing taxcategory name');
-        }
-
         if ($this->getPercent() === null) {
             throw new \InvalidArgumentException('Missing taxcategory percent');
         }
@@ -135,19 +139,25 @@ class TaxCategory implements XmlSerializable
             [
                 'name' => Schema::CBC . 'ID',
                 'value' => $this->getId(),
-                'attributes' => [
-                    'schemeID' => TaxCategory::UNCL5305,
-                    'schemeName' => 'Duty or tax or fee category'
-                ]
+                'attributes' => $this->idAttributes,
             ],
-            Schema::CBC . 'Name' => $this->name,
+        ]);
+
+        if ($this->name != null) {
+            $writer->write([
+                Schema::CBC . 'Name' => $this->name,
+            ]);
+        }
+        $writer->write([
             Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
         ]);
 
-        $writer->write([
-            Schema::CBC . 'TaxExemptionReasonCode' => null,
-            Schema::CBC . 'TaxExemptionReason' => null,
-        ]);
+        if ($this->taxExemptionReasonCode != null) {
+            $writer->write([
+                Schema::CBC . 'TaxExemptionReasonCode' => $this->taxExemptionReasonCode,
+                Schema::CBC . 'TaxExemptionReason' => $this->taxExemptionReason,
+            ]);
+        }
 
         if ($this->taxScheme != null) {
             $writer->write([Schema::CAC . 'TaxScheme' => $this->taxScheme]);

--- a/src/TaxScheme.php
+++ b/src/TaxScheme.php
@@ -9,6 +9,7 @@ class TaxScheme implements XmlSerializable
 {
     private $id;
     private $taxTypeCode;
+    private $name;
 
     /**
      * @return mixed
@@ -46,11 +47,31 @@ class TaxScheme implements XmlSerializable
         return $this;
     }
 
+    /**
+     * @param mixed $name
+     * @return int
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
     public function xmlSerialize(Writer $writer)
     {
         $writer->write([
-            Schema::CBC . 'ID' => $this->id,
-            Schema::CBC . 'TaxTypeCode' => $this->taxTypeCode
+            Schema::CBC . 'ID' => $this->id
         ]);
+        if ($this->taxTypeCode != null) {
+            $writer->write([
+                Schema::CBC . 'TaxTypeCode' => $this->taxTypeCode
+            ]);
+        }
+        if ($this->name != null) {
+            $writer->write([
+                Schema::CBC . 'Name' => $this->name
+            ]);
+        }
     }
+
 }

--- a/tests/EN16931Test.php
+++ b/tests/EN16931Test.php
@@ -34,6 +34,20 @@ class EN16931Test extends TestCase
         $sle->setRegistrationName('Supplier Company Name');
         $sle->setCompanyId('Company Registration');
 
+        $financialInstitutionBranch = (new \NumNum\UBL\FinancialInstitutionBranch())
+            ->setId('RABONL2U');
+        
+        $payeeFinancialAccount = (new \NumNum\UBL\PayeeFinancialAccount())
+           ->setFinancialInstitutionBranch($financialInstitutionBranch)
+            ->setName('Customer Account Holder')
+            ->setId('NL00RABO0000000000');
+
+        $paymentMeans = (new \NumNum\UBL\PaymentMeans())
+            ->setPayeeFinancialAccount($payeeFinancialAccount)
+            ->setPaymentMeansCode(31, [])
+            ->setPaymentId('our invoice 1234');
+            
+
         // Supplier company node
         $supplierCompany = (new \NumNum\UBL\Party())
             ->setName('Supplier Company Name')
@@ -119,6 +133,7 @@ class EN16931Test extends TestCase
             ->setInvoiceLines($invoiceLines)
             ->setLegalMonetaryTotal($legalMonetaryTotal)
             ->setPaymentTerms($paymentTerms)
+            ->setPaymentMeans($paymentMeans)
             ->setTaxTotal($taxTotal);
 
         // Test created object

--- a/tests/EN16931Test.php
+++ b/tests/EN16931Test.php
@@ -36,7 +36,7 @@ class EN16931Test extends TestCase
 
         $financialInstitutionBranch = (new \NumNum\UBL\FinancialInstitutionBranch())
             ->setId('RABONL2U');
-        
+
         $payeeFinancialAccount = (new \NumNum\UBL\PayeeFinancialAccount())
            ->setFinancialInstitutionBranch($financialInstitutionBranch)
             ->setName('Customer Account Holder')
@@ -46,7 +46,7 @@ class EN16931Test extends TestCase
             ->setPayeeFinancialAccount($payeeFinancialAccount)
             ->setPaymentMeansCode(31, [])
             ->setPaymentId('our invoice 1234');
-            
+
 
         // Supplier company node
         $supplierCompany = (new \NumNum\UBL\Party())

--- a/tests/SimpleCreditNoteTest.php
+++ b/tests/SimpleCreditNoteTest.php
@@ -89,6 +89,7 @@ class SimpleCreditNoteTest extends TestCase
         // Invoice object
         $invoice = (new \NumNum\UBL\Invoice())
             ->setId(1234)
+            ->setCopyIndicator(false)
             ->setIssueDate(new \DateTime())
             ->setAccountingSupplierParty($supplierCompany)
             ->setAccountingCustomerParty($clientCompany)
@@ -108,5 +109,6 @@ class SimpleCreditNoteTest extends TestCase
         $dom->loadXML($outputXMLString);
 
         $this->assertEquals(true, $dom->schemaValidate($this->schema));
+
     }
 }

--- a/tests/SimpleUBL22InvoiceTest.php
+++ b/tests/SimpleUBL22InvoiceTest.php
@@ -90,6 +90,7 @@ class SimpleUBL22InvoiceTest extends TestCase
         $invoice = (new \NumNum\UBL\Invoice())
             ->setUBLVersionID('2.2')
             ->setId(1234)
+            ->setCopyIndicator(false)
             ->setIssueDate(new \DateTime())
             ->setAccountingSupplierParty($supplierCompany)
             ->setAccountingCustomerParty($clientCompany)


### PR DESCRIPTION
Added support for EN16931 1.3.1, the European standard format.
The format is validated with online checkers:
- https://test.simplerinvoicing.org/validate
- https://peppol.helger.com/public/locale-en_US/menuitem-validation

This required some changes which also impacts the existing functionality:
- removed generation of empty tags (TaxExemptionReason, TaxExemptionReasonCode and TaxTypeCode)
- remove default of CopyIndicator and set it in the unit test files

A unit test was added for the EN16931 format.
