### PR TITLE
Add invoice note

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -16,6 +16,7 @@ class Invoice implements XmlSerializable
     private $copyIndicator;
     private $issueDate;
     private $invoiceTypeCode = InvoiceTypeCode::INVOICE;
+    private $note;
     private $taxPointDate;
     private $dueDate;
     private $paymentTerms;
@@ -161,6 +162,24 @@ class Invoice implements XmlSerializable
     public function setInvoiceTypeCode(string $invoiceTypeCode)
     {
         $this->invoiceTypeCode = $invoiceTypeCode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->note;
+    }
+
+    /**
+     * @param string $note
+     * @return Invoice
+     */
+    public function setNote(string $note)
+    {
+        $this->note = $note;
         return $this;
     }
 
@@ -485,6 +504,12 @@ class Invoice implements XmlSerializable
                 'value' => $this->invoiceTypeCode
             ]
         ]);
+
+        if ($this->note !== null) {
+            $writer->write([
+                Schema::CBC . 'Note' => $this->note
+            ]);
+        }
 
         if ($this->taxPointDate !== null) {
             $writer->write([

--- a/tests/EN16931Test.php
+++ b/tests/EN16931Test.php
@@ -168,6 +168,6 @@ class EN16931Test extends TestCase
         $response = $client->validate(array('XML' => $outputXMLString, 'VESID' => 'eu.cen.en16931:ubl:1.3.1'));
         $this->assertEquals('SUCCESS', $response->mostSevereErrorLevel);
 
-        file_put_contents('EN16931Test.xml', $outputXMLString);
+        // file_put_contents('EN16931Test.xml', $outputXMLString);
     }
 }

--- a/tests/EN16931Test.php
+++ b/tests/EN16931Test.php
@@ -140,6 +140,7 @@ class EN16931Test extends TestCase
             ->setCustomizationID('urn:cen.eu:en16931:2017')
             ->setId(1234)
             ->setIssueDate(new \DateTime())
+            ->setNote('invoice note')
             ->setDelivery($delivery)
             ->setAccountingSupplierParty($supplierCompany)
             ->setAccountingCustomerParty($clientCompany)
@@ -167,6 +168,6 @@ class EN16931Test extends TestCase
         $response = $client->validate(array('XML' => $outputXMLString, 'VESID' => 'eu.cen.en16931:ubl:1.3.1'));
         $this->assertEquals('SUCCESS', $response->mostSevereErrorLevel);
 
-        // file_put_contents('EN16931Test.xml', $outputXMLString);
+        file_put_contents('EN16931Test.xml', $outputXMLString);
     }
 }


### PR DESCRIPTION
The 'Note' field of Invoice is added. Tested using the EN16931 test.
This field is used in Exact Online as the invoice description field.