### PR TITLE
Switch position of PartyLegalEntity with Contact

### DIFF
--- a/src/Party.php
+++ b/src/Party.php
@@ -149,15 +149,15 @@ class Party implements XmlSerializable
             ]);
         }
 
-        if ($this->contact !== null) {
-            $writer->write([
-                Schema::CAC . 'Contact' => $this->contact
-            ]);
-        }
-
         if ($this->legalEntity !== null) {
             $writer->write([
                 Schema::CAC . 'PartyLegalEntity' => $this->legalEntity
+            ]);
+        }
+
+        if ($this->contact !== null) {
+            $writer->write([
+                Schema::CAC . 'Contact' => $this->contact
             ]);
         }
     }


### PR DESCRIPTION
I'm not totally sure, if this should even matter, but the german EN16931 standard (called Xrechnung) is complaining about my ubl invoices because it seems, that the order of the elements in Party are not valid.

So this PR switches the positions of PartyLegalEntity and Contact, see: https://portal3.gefeg.com/projectdata/invoice/deliverables/installed/publishingproject/xrechnung%201.2.0%20-%20(01.01.2019%20-%2031.12.2019)/xrechnung_ubl_invoice_v1.2.0_18.12.2018.scm/html/de/02118.htm