### PR TITLE
Make package available for php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1||^8.0",
         "sabre/xml": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Since the package seems to be completely compatible with PHP 8 I went ahead and added PHP 8 support in composer. This is currently preventing us upgrading to PHP 8.

<img width="657" alt="Screenshot 2021-03-17 at 15 03 28" src="https://user-images.githubusercontent.com/1062751/111480265-17a90700-8732-11eb-8102-49f4066b9fcd.png">

Related issue #24.