### PR TITLE
Support UBL.be format

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -2,4 +2,25 @@
 
 ### New features & improvements
 
+1. AdditionalDocumentReference  
+   - Added `DocumentDescription` 
+2. Attachment
+   - Added `ExternalReference` (`URI`) as an alternative for an `EmbeddedDocumentBinaryObject`
+3. ClassifiedTaxCategory
+   - Fixed the appearing order of `Name` and `Percent`
+4. Country
+   - Added attribute `listID="ISO3166-1:Alpha2"`
+5. Invoice
+   - Added `ProfileID`
+   - Added support for multiple `AdditionalDocumentReference` children
+6. InvoiceLine and Price
+   - Added attribute `unitCodeListID="UNECERec20"`
+7. Item
+   - Made `Description` optional
+7. Party
+   - Added `EndpointID`
+   - Made `PartyName` optional
+
 ### Breaking changes
+
+Changed `InvoiceLine`'s default `UnitCode` from `'MON'` to `UnitCode::UNIT` (in order to match `Price`'s default UnitCode).

--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -8,16 +8,12 @@
    - Added `ExternalReference` (`URI`) as an alternative for an `EmbeddedDocumentBinaryObject`
 3. ClassifiedTaxCategory
    - Fixed the appearing order of `Name` and `Percent`
-4. Country
-   - Added attribute `listID="ISO3166-1:Alpha2"`
-5. Invoice
+4. Invoice
    - Added `ProfileID`
    - Added support for multiple `AdditionalDocumentReference` children
-6. InvoiceLine and Price
-   - Added attribute `unitCodeListID="UNECERec20"`
-7. Item
+5. Item
    - Made `Description` optional
-7. Party
+6. Party
    - Added `EndpointID`
    - Made `PartyName` optional
 

--- a/src/AdditionalDocumentReference.php
+++ b/src/AdditionalDocumentReference.php
@@ -9,6 +9,7 @@ class AdditionalDocumentReference implements XmlSerializable
 {
     private $id;
     private $documentType;
+    private $documentDescription;
     private $attachment;
 
     /**
@@ -48,6 +49,24 @@ class AdditionalDocumentReference implements XmlSerializable
     }
 
     /**
+     * @return string
+     */
+    public function getDocumentDescription(): ?string
+    {
+        return $this->documentDescription;
+    }
+
+    /**
+     * @param string $documentDescription
+     * @return AdditionalDocumentReference
+     */
+    public function setDocumentDescription(string $documentDescription): AdditionalDocumentReference
+    {
+        $this->documentDescription = $documentDescription;
+        return $this;
+    }
+
+    /**
      * @return Attachment
      */
     public function getAttachment(): ?Attachment
@@ -77,6 +96,11 @@ class AdditionalDocumentReference implements XmlSerializable
         if ($this->documentType !== null) {
             $writer->write([
                 Schema::CAC . 'DocumentType' => $this->documentType
+            ]);
+        }
+        if ($this->documentDescription !== null) {
+            $writer->write([
+                Schema::CBC . 'DocumentDescription' => $this->documentDescription
             ]);
         }
         $writer->write([ Schema::CAC . 'Attachment' => $this->attachment ]);

--- a/src/ClassifiedTaxCategory.php
+++ b/src/ClassifiedTaxCategory.php
@@ -178,13 +178,9 @@ class ClassifiedTaxCategory implements XmlSerializable
         }
 
         $writer->write([
-            [
-                'name' => Schema::CBC . 'ID',
-                'value' => $this->getId(),
-                'attributes' => $schemeAttributes
-
-            ],
-            Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
+            'name' => Schema::CBC . 'ID',
+            'value' => $this->getId(),
+            'attributes' => $schemeAttributes
         ]);
 
         if ($this->name !== null) {
@@ -192,6 +188,10 @@ class ClassifiedTaxCategory implements XmlSerializable
                 Schema::CBC . 'Name' => $this->name,
             ]);
         }
+
+        $writer->write([
+            Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
+        ]);
 
         if ($this->taxExemptionReasonCode !== null) {
             $writer->write([

--- a/src/Country.php
+++ b/src/Country.php
@@ -38,9 +38,6 @@ class Country implements XmlSerializable
         $writer->write([
             'name' => Schema::CBC . 'IdentificationCode',
             'value' => $this->identificationCode,
-            'attributes' => [
-                'listID' => 'ISO3166-1:Alpha2'
-            ]
         ]);
     }
 }

--- a/src/Country.php
+++ b/src/Country.php
@@ -36,7 +36,11 @@ class Country implements XmlSerializable
     public function xmlSerialize(Writer $writer)
     {
         $writer->write([
-            Schema::CBC . 'IdentificationCode' => $this->identificationCode,
+            'name' => Schema::CBC . 'IdentificationCode',
+            'value' => $this->identificationCode,
+            'attributes' => [
+                'listID' => 'ISO3166-1:Alpha2'
+            ]
         ]);
     }
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -642,10 +642,11 @@ class Invoice implements XmlSerializable
         }
 
         if (!empty($this->additionalDocumentReferences)) {
-            foreach ($this->additionalDocumentReferences as $additionalDocumentReference)
-            $writer->write([
-                Schema::CAC . 'AdditionalDocumentReference' => $additionalDocumentReference
-            ]);
+            foreach ($this->additionalDocumentReferences as $additionalDocumentReference) {
+                $writer->write([
+                    Schema::CAC . 'AdditionalDocumentReference' => $additionalDocumentReference
+                ]);
+            }
         }
 
         if ($this->supplierAssignedAccountID !== null) {

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -12,6 +12,7 @@ class Invoice implements XmlSerializable
 {
     private $UBLVersionID = '2.1';
     private $customizationID = '1.0';
+    private $profileID;
     private $id;
     private $copyIndicator;
     private $issueDate;
@@ -28,7 +29,7 @@ class Invoice implements XmlSerializable
     private $legalMonetaryTotal;
     private $invoiceLines;
     private $allowanceCharges;
-    private $additionalDocumentReference;
+    private $additionalDocumentReferences = [];
     private $documentCurrencyCode = 'EUR';
     private $buyerReference;
     private $accountingCostCode;
@@ -78,9 +79,19 @@ class Invoice implements XmlSerializable
      * @param mixed $customizationID
      * @return Invoice
      */
-    public function setCustomizationID(?string $id): Invoice
+    public function setCustomizationID(?string $customizationID): Invoice
     {
-        $this->customizationID = $id;
+        $this->customizationID = $customizationID;
+        return $this;
+    }
+
+    /**
+     * @param mixed $profileID
+     * @return Invoice
+     */
+    public function setProfileID(?string $profileID): Invoice
+    {
+        $this->profileID = $profileID;
         return $this;
     }
 
@@ -370,7 +381,7 @@ class Invoice implements XmlSerializable
      */
     public function getAdditionalDocumentReference(): ?AdditionalDocumentReference
     {
-        return $this->additionalDocumentReference;
+        return $this->additionalDocumentReferences[0] ?? null;
     }
 
     /**
@@ -379,7 +390,17 @@ class Invoice implements XmlSerializable
      */
     public function setAdditionalDocumentReference(AdditionalDocumentReference $additionalDocumentReference): Invoice
     {
-        $this->additionalDocumentReference = $additionalDocumentReference;
+        $this->additionalDocumentReferences = [$additionalDocumentReference];
+        return $this;
+    }
+
+    /**
+     * @param AdditionalDocumentReference $additionalDocumentReference
+     * @return Invoice
+     */
+    public function addAdditionalDocumentReference(AdditionalDocumentReference $additionalDocumentReference): Invoice
+    {
+        $this->additionalDocumentReferences[] = $additionalDocumentReference;
         return $this;
     }
 
@@ -540,6 +561,15 @@ class Invoice implements XmlSerializable
         $writer->write([
             Schema::CBC . 'UBLVersionID' => $this->UBLVersionID,
             Schema::CBC . 'CustomizationID' => $this->customizationID,
+        ]);
+
+        if ($this->profileID !== null) {
+            $writer->write([
+                Schema::CBC . 'ProfileID' => $this->profileID
+            ]);
+        }
+
+        $writer->write([
             Schema::CBC . 'ID' => $this->id
         ]);
 
@@ -611,9 +641,10 @@ class Invoice implements XmlSerializable
             ]);
         }
 
-        if ($this->additionalDocumentReference !== null) {
+        if (!empty($this->additionalDocumentReferences)) {
+            foreach ($this->additionalDocumentReferences as $additionalDocumentReference)
             $writer->write([
-                Schema::CAC . 'AdditionalDocumentReference' => $this->additionalDocumentReference
+                Schema::CAC . 'AdditionalDocumentReference' => $additionalDocumentReference
             ]);
         }
 

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -240,7 +240,6 @@ class InvoiceLine implements XmlSerializable
                 'value' => number_format($this->invoicedQuantity, 2, '.', ''),
                 'attributes' => [
                     'unitCode' => $this->unitCode,
-                    'unitCodeListID' => 'UNECERec20',
                 ]
             ],
             [

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -10,7 +10,7 @@ class InvoiceLine implements XmlSerializable
     private $id;
     private $invoicedQuantity;
     private $lineExtensionAmount;
-    private $unitCode = 'MON';
+    private $unitCode = UnitCode::UNIT;
     private $taxTotal;
     private $invoicePeriod;
     private $note;

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -239,7 +239,8 @@ class InvoiceLine implements XmlSerializable
                 'name' => Schema::CBC . 'InvoicedQuantity',
                 'value' => number_format($this->invoicedQuantity, 2, '.', ''),
                 'attributes' => [
-                    'unitCode' => $this->unitCode
+                    'unitCode' => $this->unitCode,
+                    'unitCodeListID' => 'UNECERec20',
                 ]
             ],
             [

--- a/src/Item.php
+++ b/src/Item.php
@@ -111,8 +111,13 @@ class Item implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
+        if (!empty($this->getDescription())) {
+            $writer->write([
+                Schema::CBC . 'Description' => $this->description
+            ]);
+        }
+
         $writer->write([
-            Schema::CBC . 'Description' => $this->description,
             Schema::CBC . 'Name' => $this->name
         ]);
 

--- a/src/Party.php
+++ b/src/Party.php
@@ -14,6 +14,8 @@ class Party implements XmlSerializable
     private $contact;
     private $partyTaxScheme;
     private $legalEntity;
+    private $endpointID;
+    private $endpointID_schemeID;
 
     /**
      * @return string
@@ -142,6 +144,18 @@ class Party implements XmlSerializable
     }
 
     /**
+     * @param $endpointID
+     * @param int|string $schemeID See list at https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/
+     * @return Party
+     */
+    public function setEndpointID($endpointID, $schemeID): Party
+    {
+        $this->endpointID = $endpointID;
+        $this->endpointID_schemeID = $schemeID;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      *
      * @param Writer $writer
@@ -149,6 +163,20 @@ class Party implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
+        if ($this->endpointID !== null && $this->endpointID_schemeID !== null) {
+            $writer->write([
+                [
+                    'name' => Schema::CBC . 'EndpointID',
+                    'value' => $this->endpointID,
+                    'attributes' => [
+                        'schemeID' => is_numeric($this->endpointID_schemeID)
+                            ? sprintf('%04d', +$this->endpointID_schemeID)
+                            : $this->endpointID_schemeID
+                    ]
+                ]
+            ]);
+        }
+
         if ($this->partyIdentificationId !== null) {
             $writer->write([
                 Schema::CAC . 'PartyIdentification' => [
@@ -157,10 +185,15 @@ class Party implements XmlSerializable
             ]);
         }
 
+        if ($this->name !== null) {
+            $writer->write([
+                Schema::CAC . 'PartyName' => [
+                    Schema::CBC . 'Name' => $this->name
+                ]
+            ]);
+        }
+
         $writer->write([
-            Schema::CAC . 'PartyName' => [
-                Schema::CBC . 'Name' => $this->name
-            ],
             Schema::CAC . 'PostalAddress' => $this->postalAddress
         ]);
 

--- a/src/Price.php
+++ b/src/Price.php
@@ -87,7 +87,6 @@ class Price implements XmlSerializable
                 'value' => number_format($this->baseQuantity, 2, '.', ''),
                 'attributes' => [
                     'unitCode' => $this->unitCode,
-                    'unitCodeListID' => 'UNECERec20',
                 ]
             ]
         ]);

--- a/src/Price.php
+++ b/src/Price.php
@@ -86,7 +86,8 @@ class Price implements XmlSerializable
                 'name' => Schema::CBC . 'BaseQuantity',
                 'value' => number_format($this->baseQuantity, 2, '.', ''),
                 'attributes' => [
-                    'unitCode' => $this->unitCode
+                    'unitCode' => $this->unitCode,
+                    'unitCodeListID' => 'UNECERec20',
                 ]
             ]
         ]);


### PR DESCRIPTION
Hello! This pull request contains quite a few unrelated changes; I needed all of it to be able to (mostly) support UBL.be's format (while at the same time also supporting, as much  as possible from a few other formats). 

The only breaking change is that I've had to change the default unitCode for InvoiceLines in order to make it match the default unitCode for Price objects (... but it really makes no sense having different defaults for them).

Everything else should be backwards compatible. A few added attributes may be unneeded in some formats, but that should not result in any error; at most a warning.

If you believe this is fine, I will fill in the next-release.md. If not, no problem, then I'll just leave this in our own fork :) 