### PR TITLE
fix Name position in TaxScheme + add CurrencyCode

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -2,4 +2,7 @@
 
 ### New features & improvements
 
+- Fix <cbc:Name /> position in <cac:TaxScheme /> - Thanks [@tgeorgel](https://github.com/tgeorgel)
+- Add PartyIdentificationSchemeName to <cac:Party /> - Thanks [@tgeorgel](https://github.com/tgeorgel)
+
 ### Breaking changes

--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -4,5 +4,6 @@
 
 - Fix <cbc:Name /> position in <cac:TaxScheme /> - Thanks [@tgeorgel](https://github.com/tgeorgel)
 - Add PartyIdentificationSchemeName to <cac:Party /> - Thanks [@tgeorgel](https://github.com/tgeorgel)
-
+- Fix <cac:InvoicePeriod />, <cac:OrderReference />, <cac:ContractDocumentReference /> sorting
+-
 ### Breaking changes

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -625,12 +625,6 @@ class Invoice implements XmlSerializable
             ]);
         }
 
-        if ($this->contractDocumentReference !== null) {
-            $writer->write([
-                Schema::CAC . 'ContractDocumentReference' => $this->contractDocumentReference,
-            ]);
-        }
-
         if ($this->invoicePeriod != null) {
             $writer->write([
                 Schema::CAC . 'InvoicePeriod' => $this->invoicePeriod
@@ -640,6 +634,12 @@ class Invoice implements XmlSerializable
         if ($this->orderReference != null) {
             $writer->write([
                 Schema::CAC . 'OrderReference' => $this->orderReference
+            ]);
+        }
+
+        if ($this->contractDocumentReference !== null) {
+            $writer->write([
+                Schema::CAC . 'ContractDocumentReference' => $this->contractDocumentReference,
             ]);
         }
 

--- a/src/Party.php
+++ b/src/Party.php
@@ -10,6 +10,7 @@ class Party implements XmlSerializable
     private $name;
     private $partyIdentificationId;
     private $partyIdentificationSchemeId;
+    private $partyIdentificationSchemeName;
     private $postalAddress;
     private $physicalLocation;
     private $contact;
@@ -69,6 +70,24 @@ class Party implements XmlSerializable
     public function setPartyIdentificationSchemeId(?string $partyIdentificationSchemeId): Party
     {
         $this->partyIdentificationSchemeId = $partyIdentificationSchemeId;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPartyIdentificationSchemeName(): ?string
+    {
+        return $this->partyIdentificationSchemeName;
+    }
+
+    /**
+     * @param string $partyIdentificationSchemeName
+     * @return Party
+     */
+    public function setPartyIdentificationSchemeName(?string $partyIdentificationSchemeName): Party
+    {
+        $this->partyIdentificationSchemeName = $partyIdentificationSchemeName;
         return $this;
     }
 
@@ -201,6 +220,10 @@ class Party implements XmlSerializable
 
             if (!empty($this->getPartyIdentificationSchemeId())) {
                 $partyIdentificationAttributes['schemeID'] = $this->getPartyIdentificationSchemeId();
+            }
+
+            if (!empty($this->getPartyIdentificationSchemeName())) {
+                $partyIdentificationAttributes['schemeName'] = $this->getPartyIdentificationSchemeName();
             }
 
             $writer->write([

--- a/src/TaxScheme.php
+++ b/src/TaxScheme.php
@@ -8,8 +8,9 @@ use Sabre\Xml\XmlSerializable;
 class TaxScheme implements XmlSerializable
 {
     private $id;
-    private $taxTypeCode;
     private $name;
+    private $taxTypeCode;
+    private $currencyCode;
 
     /**
      * @return string
@@ -26,6 +27,24 @@ class TaxScheme implements XmlSerializable
     public function setId(string $id): TaxScheme
     {
         $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return TaxScheme
+     */
+    public function setName(?string $name)
+    {
+        $this->name = $name;
         return $this;
     }
 
@@ -50,18 +69,18 @@ class TaxScheme implements XmlSerializable
     /**
      * @return string
      */
-    public function getName(): ?string
+    public function getCurrencyCode(): ?string
     {
-        return $this->name;
+        return $this->currencyCode;
     }
 
     /**
-     * @param string $name
+     * @param string $currencyCode
      * @return TaxScheme
      */
-    public function setName(?string $name)
+    public function setCurrencyCode(?string $currencyCode)
     {
-        $this->name = $name;
+        $this->currencyCode = $currencyCode;
         return $this;
     }
 
@@ -76,14 +95,19 @@ class TaxScheme implements XmlSerializable
         $writer->write([
             Schema::CBC . 'ID' => $this->id
         ]);
+        if ($this->name !== null) {
+            $writer->write([
+                Schema::CBC . 'Name' => $this->name
+            ]);
+        }
         if ($this->taxTypeCode !== null) {
             $writer->write([
                 Schema::CBC . 'TaxTypeCode' => $this->taxTypeCode
             ]);
         }
-        if ($this->name !== null) {
+        if ($this->currencyCode !== null) {
             $writer->write([
-                Schema::CBC . 'Name' => $this->name
+                Schema::CBC . 'CurrencyCode' => $this->currencyCode
             ]);
         }
     }

--- a/tests/PartyIdentificationSchemeNameTest.php
+++ b/tests/PartyIdentificationSchemeNameTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace NumNum\UBL\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test an UBL2.2 invoice document
+ */
+class PartyIdentificationSchemeNameTest extends TestCase
+{
+    private $schema = 'http://docs.oasis-open.org/ubl/os-UBL-2.2/xsd/maindoc/UBL-Invoice-2.2.xsd';
+
+    /** @test */
+    public function testIfXMLIsValid()
+    {
+        // Address country
+        $country = (new \NumNum\UBL\Country())
+            ->setIdentificationCode('BE');
+
+        // Full address
+        $address = (new \NumNum\UBL\Address())
+            ->setStreetName('Korenmarkt')
+            ->setBuildingNumber(1)
+            ->setCityName('Gent')
+            ->setPostalZone('9000')
+            ->setCountry($country);
+
+        // Supplier company node
+        $supplierCompany = (new \NumNum\UBL\Party())
+            ->setName('Supplier Company Name')
+            ->setPhysicalLocation($address)
+            ->setPostalAddress($address)
+            ->setPartyIdentificationSchemeName("SomeScheme");
+
+        // Client company node
+        $clientCompany = (new \NumNum\UBL\Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new \NumNum\UBL\LegalMonetaryTotal())
+            ->setPayableAmount(10 + 2)
+            ->setAllowanceTotalAmount(0);
+
+        // Tax scheme
+        $taxScheme = (new \NumNum\UBL\TaxScheme())
+            ->setId(0);
+
+        // Product
+        $productItem = (new \NumNum\UBL\Item())
+            ->setName('Product Name')
+            ->setDescription('Product Description');
+
+        // Price
+        $price = (new \NumNum\UBL\Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(\NumNum\UBL\UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line tax totals
+        $lineTaxTotal = (new \NumNum\UBL\TaxTotal())
+            ->setTaxAmount(2.1);
+
+        // Invoice Line(s)
+        $invoiceLine = (new \NumNum\UBL\InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setTaxTotal($lineTaxTotal)
+            ->setInvoicedQuantity(1);
+
+        $invoiceLines = [$invoiceLine];
+
+        // Total Taxes
+        $taxCategory = (new \NumNum\UBL\TaxCategory())
+            ->setId(0)
+            ->setName('VAT21%')
+            ->setPercent(.21)
+            ->setTaxScheme($taxScheme);
+
+        $taxSubTotal = (new \NumNum\UBL\TaxSubTotal())
+            ->setTaxableAmount(10)
+            ->setTaxAmount(2.1)
+            ->setTaxCategory($taxCategory);
+
+        $taxTotal = (new \NumNum\UBL\TaxTotal())
+            ->addTaxSubTotal($taxSubTotal)
+            ->setTaxAmount(2.1);
+
+        $contractDocumentReference = (new \NumNum\UBL\ContractDocumentReference())
+            ->setId("123Test");
+
+        $invoicePeriod = (new \NumNum\UBL\InvoicePeriod())
+            ->setStartDate(new \DateTime('-31 days'))
+            ->setEndDate(new \DateTime());
+
+        // Invoice object
+        $invoice = (new \NumNum\UBL\Invoice())
+            ->setUBLVersionID('2.2')
+            ->setId(1234)
+            ->setCopyIndicator(false)
+            ->setIssueDate(new \DateTime())
+            ->setInvoiceTypeCode(\NumNum\UBL\InvoiceTypeCode::INVOICE)
+            ->setDueDate(new \DateTime())
+            ->setAccountingSupplierParty($supplierCompany)
+            ->setAccountingCustomerParty($clientCompany)
+            ->setInvoiceLines($invoiceLines)
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setTaxTotal($taxTotal)
+            ->setContractDocumentReference($contractDocumentReference)
+            ->setBuyerReference("SomeReference")
+            ->setInvoicePeriod($invoicePeriod);
+
+        // Test created object
+        // Use \NumNum\UBL\Generator to generate an XML string
+        $generator = new \NumNum\UBL\Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        // Create PHP Native DomDocument object, that can be
+        // used to validate the generate XML
+        $dom = new \DOMDocument;
+        $dom->loadXML($outputXMLString);
+
+        $dom->save('./tests/PartyIdentificationSchemeNameTest.xml');
+
+        $this->assertEquals(true, $dom->schemaValidate($this->schema));
+    }
+}


### PR DESCRIPTION
Hi there 🙂

### TaxScheme

Based on the [Schema documentation](http://www.datypic.com/sc/ubl21/t-cac_TaxSchemeType.html), the TaxScheme property was having an issue, as the `Name` property should be displayed **before** the `TaxTypeCode` property (was displayed after).

I just reverted positions of those two. I also added the `CurrencyCode` property. 

The [Ecosio validator](https://ecosio.com/en/peppol-and-xml-document-validator/) is now happy, so is Chorus Pro. 

### Party

Added `PartyIdentificationSchemeName`, similar to `PartyIdentificationSchemeId` : 
```
<cac:PartyIdentification>
  <cbc:ID schemeName="1">69468811942367</cbc:ID>
</cac:PartyIdentification>
```

Used by ChorusPro.

Thanks!