### PR TITLE
Ensure that an invoice line with VAT category code "Not subject to VA…

### DIFF
--- a/src/ClassifiedTaxCategory.php
+++ b/src/ClassifiedTaxCategory.php
@@ -148,7 +148,7 @@ class ClassifiedTaxCategory implements XmlSerializable
             throw new InvalidArgumentException('Missing taxcategory id');
         }
 
-        if ($this->getPercent() === null) {
+        if ($this->getId() !== UNCL5305::OUTSIDE_TAX_SCOPE && $this->getPercent() === null) {
             throw new InvalidArgumentException('Missing taxcategory percent');
         }
     }
@@ -183,9 +183,11 @@ class ClassifiedTaxCategory implements XmlSerializable
             ]);
         }
 
-        $writer->write([
-            Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
-        ]);
+        if ($this->percent !== null) {
+            $writer->write([
+                Schema::CBC . 'Percent' => number_format($this->percent, 2, '.', ''),
+            ]);
+        }
 
         if ($this->taxExemptionReasonCode !== null) {
             $writer->write([


### PR DESCRIPTION
This pull request addresses the validation rule BR-O-05.

Message
[BR-O-05]-An Invoice line (BG-25) where the VAT category code (BT-151) is "Not subject to VAT" shall not contain an Invoiced item VAT rate (BT-152).

Context
cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT'] | cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory[normalize-space(cbc:ID) = 'O'][cac:TaxScheme/normalize-space(upper-case(cbc:ID))='VAT']

Test
not(cbc:Percent)