### PR TITLE
Peppol 3.0 BR-64 : The Item standard identifier (BT-157) shall have a Scheme identifier.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog for <next-version>
+
+### New features & improvements
+
+- Support for `<cav:Item>` `<cac:StandardItemIdentification>` --> `cbc:IDPeppol` Scheme identifier - Thanks [@dragonfly4](https://github.com/dragonfly4)
+
 # Changelog for version 1.17.0
 
 ### New features & improvements

--- a/src/Item.php
+++ b/src/Item.php
@@ -12,6 +12,7 @@ class Item implements XmlSerializable
     private $buyersItemIdentification;
     private $sellersItemIdentification;
     private $standardItemIdentification;
+    private $standardItemIdentificationAttributes = [];
     private $classifiedTaxCategory;
 
     /**
@@ -80,9 +81,12 @@ class Item implements XmlSerializable
      * @param mixed $standardItemIdentification
      * @return Item
      */
-    public function setStandardItemIdentification(?string $standardItemIdentification): Item
+    public function setStandardItemIdentification(?string $standardItemIdentification, $attributes = null): Item
     {
         $this->standardItemIdentification = $standardItemIdentification;
+        if (isset($attributes)) {
+            $this->standardItemIdentificationAttributes = $attributes;
+        }
         return $this;
     }
 
@@ -159,8 +163,11 @@ class Item implements XmlSerializable
         if (!empty($this->getStandardItemIdentification())) {
             $writer->write([
                 Schema::CAC . 'StandardItemIdentification' => [
-                    Schema::CBC . 'ID' => $this->standardItemIdentification
-                ],
+                    Schema::CBC . 'ID' => [
+                    'value' => $this->standardItemIdentification,
+                    'attributes' => $this->standardItemIdentificationAttributes
+                    ]
+                ]
             ]);
         }
 


### PR DESCRIPTION
The Item standard identifier (BT-157) shall have a Scheme identifier.
https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-64/

```
Context
cac:InvoiceLine/cac:Item/cac:StandardItemIdentification/cbc:ID | cac:CreditNoteLine/cac:Item/cac:StandardItemIdentification/cbc:ID

Test
exists(@schemeID)

Usage
/ ubl:Invoice / cac:InvoiceLine / cac:Item / cac:StandardItemIdentification / cbc:ID
/ ubl:CreditNote / cac:CreditNoteLine / cac:Item / cac:StandardItemIdentification / cbc:ID
```

Add attributes for the setStandardItemIdentification function.
Extension of PR https://github.com/num-num/ubl-invoice/pull/55

Code Example
```
$productItem = (new \NumNum\UBL\Item)
->setStandardItemIdentification('874512958741', [ 'schemeID' => '0088' ]);
```

XML result
```
<cac:StandardItemIdentification>
    <cbc:ID schemeID="0088">874512958741</cbc:ID>
/cac:StandardItemIdentification>
```

schemeID value should come from the ICD list
https://docs.peppol.eu/poacc/billing/3.0/codelist/ICD/