### PR TITLE
Add cbc:PayableRoundingTotal to cac:LegalMonetaryTotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog for <next-version>
+
+### New features & improvements
+
+- Add `<cbc:PayableRoundingAmount />` to `<cac:LegalMonetaryTotal>`
+
 # Changelog for v1.19.0
 
 ### New features & improvements

--- a/src/LegalMonetaryTotal.php
+++ b/src/LegalMonetaryTotal.php
@@ -14,6 +14,7 @@ class LegalMonetaryTotal implements XmlSerializable
     private $chargeTotalAmount = 0;
     private $prepaidAmount;
     private $payableAmount = 0;
+    private $payableRoundingAmount;
 
     /**
      * @return float
@@ -141,6 +142,21 @@ class LegalMonetaryTotal implements XmlSerializable
         return $this;
     }
 
+    public function getPayableRoundingAmount(): ?float
+    {
+        return $this->payableRoundingAmount;
+    }
+
+    /**
+     * @param float|null $payableRoundingAmount
+     * @return LegalMonetaryTotal
+     */
+    public function setPayableRoundingAmount(?float $payableRoundingAmount): LegalMonetaryTotal
+    {
+        $this->payableRoundingAmount = $payableRoundingAmount;
+        return $this;
+    }
+
     /**
      * The xmlSerialize method is called during xml writing.
      *
@@ -201,6 +217,18 @@ class LegalMonetaryTotal implements XmlSerializable
                         'currencyID' => Generator::$currencyID
                     ]
                 ]
+            ]);
+        }
+
+        if ($this->payableRoundingAmount !== null) {
+            $writer->write([
+                [
+                    'name' => Schema::CBC . 'PayableRoundingAmount',
+                    'value' => number_format($this->payableRoundingAmount, 2, '.', ''),
+                    'attributes' => [
+                        'currencyID' => Generator::$currencyID
+                    ]
+                ],
             ]);
         }
 

--- a/tests/EN16931Test.php
+++ b/tests/EN16931Test.php
@@ -79,6 +79,7 @@ class EN16931Test extends TestCase
 
         $legalMonetaryTotal = (new \NumNum\UBL\LegalMonetaryTotal())
             ->setPayableAmount(10 + 2.1)
+            ->setPayableRoundingAmount(12.1)
             ->setAllowanceTotalAmount(0)
             ->setTaxInclusiveAmount(10 + 2.1)
             ->setLineExtensionAmount(10)


### PR DESCRIPTION
Adds cbc:PayableRoundingTotal to cac:LegalMonetaryTotal
https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-LegalMonetaryTotal/cbc-PayableRoundingAmount/