### PR TITLE
Allow string value for documentTypeCode in AdditionalDocumentReference

### DIFF
--- a/src/AdditionalDocumentReference.php
+++ b/src/AdditionalDocumentReference.php
@@ -50,18 +50,18 @@ class AdditionalDocumentReference implements XmlSerializable
     }
 
     /**
-     * @return int
+     * @return int|string|null
      */
-    public function getDocumentTypeCode(): ?int
+    public function getDocumentTypeCode()
     {
         return $this->documentTypeCode;
     }
 
     /**
-     * @param int $documentTypeCode
+     * @param int|string $documentTypeCode
      * @return AdditionalDocumentReference
      */
-    public function setDocumentTypeCode(int $documentTypeCode): AdditionalDocumentReference
+    public function setDocumentTypeCode($documentTypeCode): AdditionalDocumentReference
     {
         $this->documentTypeCode = $documentTypeCode;
         return $this;


### PR DESCRIPTION
Some provider allows string value for DocumentTypeCode, for example "application/pdf".

This PR allow to provide a string, while preserving support for int values.