### PR TITLE
Update AccountingParty.php

### DIFF
--- a/src/AccountingParty.php
+++ b/src/AccountingParty.php
@@ -63,7 +63,7 @@ class AccountingParty implements XmlSerializable, XmlDeserializable
      * @param Contact $accountingContact
      * @return AccountingParty
      */
-    public function setAccountingContact(Contact $accountingContact): AccountingParty
+    public function setAccountingContact(?Contact $accountingContact): AccountingParty
     {
         $this->accountingContact = $accountingContact;
         return $this;


### PR DESCRIPTION
Exception: TypeError: NumNum\UBL\AccountingParty::setAccountingContact(): Argument #1 ($accountingContact) must be of type NumNum\UBL\Contact, null given


On line 112 in num-num/ubl-invoice/src/AccountingParty.php setAccountingContact is called. Here the value of the parameter can be NULL. The function on line 66 does not support the paramater to be NULL.