### PR TITLE
Add AddressLine support to Address class

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -1,0 +1,11 @@
+# Changelog for next release
+
+### New features & improvements
+
+- Add `<cac:AddressLine>` support to `<cac:Address>` for additional unstructured address lines
+  - New `AddressLine` class with `getLine()` / `setLine()` methods
+  - `Address::getAddressLines()` - returns array of AddressLine objects
+  - `Address::setAddressLines(array $addressLines)` - set all address lines
+  - `Address::addAddressLine(AddressLine $addressLine)` - add a single address line
+  - Supports multiple `<cac:AddressLine>` elements per address (UBL 2.1 compliant)
+

--- a/src/Address.php
+++ b/src/Address.php
@@ -18,6 +18,7 @@ class Address implements XmlSerializable, XmlDeserializable
     private $cityName;
     private $postalZone;
     private $countrySubentity;
+    private $addressLines = [];
     private $country;
 
     /**
@@ -147,6 +148,34 @@ class Address implements XmlSerializable, XmlDeserializable
     }
 
     /**
+     * @return AddressLine[]
+     */
+    public function getAddressLines(): array
+    {
+        return $this->addressLines;
+    }
+
+    /**
+     * @param AddressLine[] $addressLines
+     * @return static
+     */
+    public function setAddressLines(array $addressLines)
+    {
+        $this->addressLines = $addressLines;
+        return $this;
+    }
+
+    /**
+     * @param AddressLine $addressLine
+     * @return static
+     */
+    public function addAddressLine(AddressLine $addressLine)
+    {
+        $this->addressLines[] = $addressLine;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      *
      * @param Writer $writer
@@ -184,6 +213,11 @@ class Address implements XmlSerializable, XmlDeserializable
                 Schema::CBC . 'CountrySubentity' => $this->countrySubentity,
             ]);
         }
+        foreach ($this->addressLines as $addressLine) {
+            $writer->write([
+                Schema::CAC . 'AddressLine' => $addressLine
+            ]);
+        }
         if ($this->country !== null) {
             $writer->write([
                 Schema::CAC . 'Country' => $this->country,
@@ -208,6 +242,7 @@ class Address implements XmlSerializable, XmlDeserializable
             ->setCityName(ReaderHelper::getTagValue(Schema::CBC . 'CityName', $collection))
             ->setPostalZone(ReaderHelper::getTagValue(Schema::CBC . 'PostalZone', $collection))
             ->setCountrySubentity(ReaderHelper::getTagValue(Schema::CBC . 'CountrySubentity', $collection))
+            ->setAddressLines(array_values(ReaderHelper::getArrayValue(Schema::CAC . 'AddressLine', $collection)))
             ->setCountry(ReaderHelper::getTagValue(Schema::CAC . 'Country', $collection));
     }
 }

--- a/src/AddressLine.php
+++ b/src/AddressLine.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Reader;
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlDeserializable;
+use Sabre\Xml\XmlSerializable;
+
+use function Sabre\Xml\Deserializer\keyValue;
+
+class AddressLine implements XmlSerializable, XmlDeserializable
+{
+    private $line;
+
+    /**
+     * @return string|null
+     */
+    public function getLine(): ?string
+    {
+        return $this->line;
+    }
+
+    /**
+     * @param string|null $line
+     * @return static
+     */
+    public function setLine(?string $line)
+    {
+        $this->line = $line;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer): void
+    {
+        if ($this->line !== null) {
+            $writer->write([
+                Schema::CBC . 'Line' => $this->line
+            ]);
+        }
+    }
+
+    /**
+     * The xmlDeserialize method is called during xml reading.
+     *
+     * @param Reader $reader
+     * @return static
+     */
+    public static function xmlDeserialize(Reader $reader)
+    {
+        $keyValues = keyValue($reader);
+
+        return (new static())
+            ->setLine($keyValues[Schema::CBC . 'Line'] ?? null);
+    }
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -27,6 +27,7 @@ class Reader
             Schema::CAC.        'AccountingSupplierParty'     => fn ($reader) => AccountingParty::xmlDeserialize($reader),
             Schema::CAC.        'AdditionalDocumentReference' => fn ($reader) => AdditionalDocumentReference::xmlDeserialize($reader),
             Schema::CAC.        'Address'                     => fn ($reader) => Address::xmlDeserialize($reader),
+            Schema::CAC.        'AddressLine'                 => fn ($reader) => AddressLine::xmlDeserialize($reader),
             Schema::CAC.        'AllowanceCharge'             => fn ($reader) => AllowanceCharge::xmlDeserialize($reader),
             Schema::CAC.        'Attachment'                  => fn ($reader) => Attachment::xmlDeserialize($reader),
             Schema::CAC.        'BillingReference'            => fn ($reader) => BillingReference::xmlDeserialize($reader),

--- a/tests/Read/AddressLineTest.php
+++ b/tests/Read/AddressLineTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace NumNum\UBL\Tests\Read;
+
+use NumNum\UBL\Address;
+use NumNum\UBL\AddressLine;
+use NumNum\UBL\Invoice;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test AddressLine deserialization from UBL XML
+ */
+class AddressLineTest extends TestCase
+{
+    /** @test */
+    public function testAddressLineDeserializesFromXml()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:ID>123</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cbc:StreetName>Main Street 123</cbc:StreetName>
+                <cbc:AdditionalStreetName>Building A</cbc:AdditionalStreetName>
+                <cbc:CityName>Copenhagen</cbc:CityName>
+                <cbc:PostalZone>1000</cbc:PostalZone>
+                <cac:AddressLine>
+                    <cbc:Line>3rd Floor</cbc:Line>
+                </cac:AddressLine>
+                <cac:AddressLine>
+                    <cbc:Line>Suite 5</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cbc:StreetName>Customer Street</cbc:StreetName>
+                <cbc:CityName>Amsterdam</cbc:CityName>
+                <cbc:PostalZone>1000</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">0</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">100</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = \NumNum\UBL\Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        // Get the supplier's postal address
+        $supplierParty = $invoice->getAccountingSupplierParty()->getParty();
+        $address = $supplierParty->getPostalAddress();
+
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('Main Street 123', $address->getStreetName());
+        $this->assertEquals('Building A', $address->getAdditionalStreetName());
+        $this->assertEquals('Copenhagen', $address->getCityName());
+        $this->assertEquals('1000', $address->getPostalZone());
+
+        // Verify AddressLines were deserialized
+        $addressLines = $address->getAddressLines();
+        $this->assertIsArray($addressLines);
+        $this->assertCount(2, $addressLines);
+
+        $this->assertInstanceOf(AddressLine::class, $addressLines[0]);
+        $this->assertEquals('3rd Floor', $addressLines[0]->getLine());
+
+        $this->assertInstanceOf(AddressLine::class, $addressLines[1]);
+        $this->assertEquals('Suite 5', $addressLines[1]->getLine());
+
+        // Verify Country is still parsed correctly
+        $this->assertNotNull($address->getCountry());
+        $this->assertEquals('DK', $address->getCountry()->getIdentificationCode());
+
+        // Verify customer address without AddressLines
+        $customerAddress = $invoice->getAccountingCustomerParty()->getParty()->getPostalAddress();
+        $this->assertEmpty($customerAddress->getAddressLines());
+    }
+
+    /** @test */
+    public function testSingleAddressLineDeserializes()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:ID>456</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cbc:StreetName>Test Street</cbc:StreetName>
+                <cbc:CityName>Test City</cbc:CityName>
+                <cac:AddressLine>
+                    <cbc:Line>Only One Line</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cbc:StreetName>Customer Street</cbc:StreetName>
+                <cbc:CityName>Customer City</cbc:CityName>
+                <cac:Country>
+                    <cbc:IdentificationCode>NL</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">0</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">50</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">50</cbc:LineExtensionAmount>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = \NumNum\UBL\Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $address = $invoice->getAccountingSupplierParty()->getParty()->getPostalAddress();
+        $addressLines = $address->getAddressLines();
+
+        $this->assertCount(1, $addressLines);
+        $this->assertEquals('Only One Line', $addressLines[0]->getLine());
+    }
+}
+

--- a/tests/Write/AddressLineTest.php
+++ b/tests/Write/AddressLineTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace NumNum\UBL\Tests\Write;
+
+use NumNum\UBL\Address;
+use NumNum\UBL\AddressLine;
+use NumNum\UBL\Country;
+use NumNum\UBL\Generator;
+use NumNum\UBL\Invoice;
+use NumNum\UBL\AccountingParty;
+use NumNum\UBL\InvoiceLine;
+use NumNum\UBL\Item;
+use NumNum\UBL\LegalMonetaryTotal;
+use NumNum\UBL\Party;
+use NumNum\UBL\Price;
+use NumNum\UBL\TaxCategory;
+use NumNum\UBL\TaxScheme;
+use NumNum\UBL\TaxSubTotal;
+use NumNum\UBL\TaxTotal;
+use NumNum\UBL\UnitCode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test AddressLine serialization in UBL2.1 invoice
+ */
+class AddressLineTest extends TestCase
+{
+    private $schema = 'http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd';
+
+    /** @test */
+    public function testAddressLineSerializesToXml()
+    {
+        // Address country
+        $country = (new Country())
+            ->setIdentificationCode('DK');
+
+        // Full address with AddressLines
+        $address = (new Address())
+            ->setStreetName('Main Street 123')
+            ->setAdditionalStreetName('Building A')
+            ->addAddressLine((new AddressLine())->setLine('3rd Floor'))
+            ->addAddressLine((new AddressLine())->setLine('Suite 5'))
+            ->setCityName('Copenhagen')
+            ->setPostalZone('1000')
+            ->setCountry($country);
+
+        // Supplier company node
+        $supplierCompany = (new Party())
+            ->setName('Supplier Company Name')
+            ->setPostalAddress($address);
+
+        // Client company node
+        $clientCompany = (new Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new LegalMonetaryTotal())
+            ->setPayableAmount(10 + 2)
+            ->setAllowanceTotalAmount(0);
+
+        // Tax scheme
+        $taxScheme = (new TaxScheme())
+            ->setId(0);
+
+        // Product
+        $productItem = (new Item())
+            ->setName('Product Name')
+            ->setDescription('Product Description');
+
+        // Price
+        $price = (new Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line tax totals
+        $lineTaxTotal = (new TaxTotal())
+            ->setTaxAmount(2.1);
+
+        // Invoice Line(s)
+        $invoiceLines = [];
+        $invoiceLines[] = (new InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setTaxTotal($lineTaxTotal)
+            ->setInvoicedQuantity(1);
+
+        // Total Taxes
+        $taxCategory = (new TaxCategory())
+            ->setId(0)
+            ->setName('VAT21%')
+            ->setPercent(.21)
+            ->setTaxScheme($taxScheme);
+
+        $taxSubTotal = (new TaxSubTotal())
+            ->setTaxableAmount(10)
+            ->setTaxAmount(2.1)
+            ->setTaxCategory($taxCategory);
+
+        $taxTotal = (new TaxTotal())
+            ->addTaxSubTotal($taxSubTotal)
+            ->setTaxAmount(2.1);
+
+        $accountingSupplierParty = (new AccountingParty())
+            ->setParty($supplierCompany);
+
+        $accountingCustomerParty = (new AccountingParty())
+            ->setParty($clientCompany);
+
+        // Invoice object
+        $invoice = (new Invoice())
+            ->setId(1234)
+            ->setCopyIndicator(false)
+            ->setIssueDate(new \DateTime())
+            ->setAccountingSupplierParty($accountingSupplierParty)
+            ->setAccountingCustomerParty($accountingCustomerParty)
+            ->setInvoiceLines($invoiceLines)
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setTaxTotal($taxTotal);
+
+        // Generate XML
+        $generator = new Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        // Verify AddressLine elements are present in XML
+        $this->assertStringContainsString('<cac:AddressLine>', $outputXMLString);
+        $this->assertStringContainsString('<cbc:Line>3rd Floor</cbc:Line>', $outputXMLString);
+        $this->assertStringContainsString('<cbc:Line>Suite 5</cbc:Line>', $outputXMLString);
+
+        // Create PHP Native DomDocument object for validation
+        $dom = new \DOMDocument();
+        $dom->loadXML($outputXMLString);
+
+        $this->assertEquals(true, $dom->schemaValidate($this->schema));
+    }
+
+    /** @test */
+    public function testAddressWithoutAddressLinesIsValid()
+    {
+        // Address country
+        $country = (new Country())
+            ->setIdentificationCode('BE');
+
+        // Address without AddressLines
+        $address = (new Address())
+            ->setStreetName('Korenmarkt')
+            ->setBuildingNumber(1)
+            ->setCityName('Gent')
+            ->setPostalZone('9000')
+            ->setCountry($country);
+
+        // Verify addressLines is empty array
+        $this->assertIsArray($address->getAddressLines());
+        $this->assertEmpty($address->getAddressLines());
+
+        // Supplier company node
+        $supplierCompany = (new Party())
+            ->setName('Supplier Company Name')
+            ->setPostalAddress($address);
+
+        // Client company node
+        $clientCompany = (new Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new LegalMonetaryTotal())
+            ->setPayableAmount(12)
+            ->setAllowanceTotalAmount(0);
+
+        // Tax scheme
+        $taxScheme = (new TaxScheme())
+            ->setId(0);
+
+        // Product
+        $productItem = (new Item())
+            ->setName('Product Name');
+
+        // Price
+        $price = (new Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line tax totals
+        $lineTaxTotal = (new TaxTotal())
+            ->setTaxAmount(2);
+
+        // Invoice Line(s)
+        $invoiceLines = [];
+        $invoiceLines[] = (new InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setTaxTotal($lineTaxTotal)
+            ->setInvoicedQuantity(1);
+
+        // Total Taxes
+        $taxCategory = (new TaxCategory())
+            ->setId(0)
+            ->setPercent(.20)
+            ->setTaxScheme($taxScheme);
+
+        $taxSubTotal = (new TaxSubTotal())
+            ->setTaxableAmount(10)
+            ->setTaxAmount(2)
+            ->setTaxCategory($taxCategory);
+
+        $taxTotal = (new TaxTotal())
+            ->addTaxSubTotal($taxSubTotal)
+            ->setTaxAmount(2);
+
+        $accountingSupplierParty = (new AccountingParty())
+            ->setParty($supplierCompany);
+
+        $accountingCustomerParty = (new AccountingParty())
+            ->setParty($clientCompany);
+
+        // Invoice object
+        $invoice = (new Invoice())
+            ->setId(1234)
+            ->setCopyIndicator(false)
+            ->setIssueDate(new \DateTime())
+            ->setAccountingSupplierParty($accountingSupplierParty)
+            ->setAccountingCustomerParty($accountingCustomerParty)
+            ->setInvoiceLines($invoiceLines)
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setTaxTotal($taxTotal);
+
+        // Generate XML
+        $generator = new Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        // Verify no AddressLine elements
+        $this->assertStringNotContainsString('<cac:AddressLine>', $outputXMLString);
+
+        // Create PHP Native DomDocument object for validation
+        $dom = new \DOMDocument();
+        $dom->loadXML($outputXMLString);
+
+        $this->assertEquals(true, $dom->schemaValidate($this->schema));
+    }
+
+    /** @test */
+    public function testSetAddressLinesReplacesExisting()
+    {
+        $address = (new Address())
+            ->addAddressLine((new AddressLine())->setLine('First'))
+            ->addAddressLine((new AddressLine())->setLine('Second'));
+
+        $this->assertCount(2, $address->getAddressLines());
+
+        // Replace with new array
+        $address->setAddressLines([
+            (new AddressLine())->setLine('New Line')
+        ]);
+
+        $this->assertCount(1, $address->getAddressLines());
+        $this->assertEquals('New Line', $address->getAddressLines()[0]->getLine());
+    }
+}
+


### PR DESCRIPTION
Adds support for `<cac:AddressLine>` elements in `Address`, allowing additional unstructured address lines per UBL 2.1 specification.

Changes:
- New `AddressLine` class
- `Address` now supports `getAddressLines()`, `setAddressLines()`, `addAddressLine()`
- Fixed deserialization to handle multiple elements with same tag

Usage:
```php
$address = (new Address())
    ->setStreetName('Main Street 123')
    ->addAddressLine((new AddressLine())->setLine('3rd Floor'))
    ->addAddressLine((new AddressLine())->setLine('Suite 5'))
    ->setCityName('Copenhagen')
    ->setCountry((new Country())->setIdentificationCode('DK'));
```