### PR TITLE
Add OriginCountry support to Item class

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -1,0 +1,6 @@
+# Changelog for next release
+
+### New features & improvements
+
+- Add `<cac:OriginCountry>` support to `<cac:Item>` for specifying country of origin
+

--- a/src/Item.php
+++ b/src/Item.php
@@ -20,6 +20,7 @@ class Item implements XmlSerializable, XmlDeserializable
     private $standardItemIdentificationAttributes = [];
     private $commodityClassification;
     private $classifiedTaxCategory;
+    private $originCountry;
 
     /**
      * @return string
@@ -151,6 +152,24 @@ class Item implements XmlSerializable, XmlDeserializable
     }
 
     /**
+     * @return Country
+     */
+    public function getOriginCountry(): ?Country
+    {
+        return $this->originCountry;
+    }
+
+    /**
+     * @param Country $originCountry
+     * @return Item
+     */
+    public function setOriginCountry(?Country $originCountry): Item
+    {
+        $this->originCountry = $originCountry;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      *
      * @param Writer $writer
@@ -195,6 +214,12 @@ class Item implements XmlSerializable, XmlDeserializable
             ]);
         }
 
+        if (!empty($this->getOriginCountry())) {
+            $writer->write([
+                Schema::CAC . 'OriginCountry' => $this->originCountry
+            ]);
+        }
+
         if (!empty($this->getCommodityClassification())) {
             $writer->write([
                 Schema::CAC . 'CommodityClassification' => $this->commodityClassification
@@ -222,6 +247,7 @@ class Item implements XmlSerializable, XmlDeserializable
         $nameTag = ReaderHelper::getTag(Schema::CBC . 'Name', $collection);
         $classifiedTaxCategoryTag = ReaderHelper::getTag(Schema::CAC . 'ClassifiedTaxCategory', $collection);
         $commodityClassification = ReaderHelper::getTag(Schema::CAC . 'CommodityClassification', $collection);
+        $originCountryTag = ReaderHelper::getTag(Schema::CAC . 'OriginCountry', $collection);
 
         $buyersItemIdentificationTag = ReaderHelper::getTag(Schema::CAC . 'BuyersItemIdentification', $collection);
         $buyersItemIdentificationIdTag = ReaderHelper::getTag(
@@ -249,6 +275,7 @@ class Item implements XmlSerializable, XmlDeserializable
             ->setStandardItemIdentification($standardItemIdentificationIdTag['value'] ?? null, $standardItemIdentificationIdTag['attributes'] ?? null)
             ->setClassifiedTaxCategory($classifiedTaxCategoryTag['value'] ?? null)
             ->setCommodityClassification($commodityClassification['value'] ?? null)
+            ->setOriginCountry($originCountryTag['value'] ?? null)
         ;
     }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -46,6 +46,7 @@ class Reader
             Schema::CAC.        'LegalMonetaryTotal'          => fn ($reader) => LegalMonetaryTotal::xmlDeserialize($reader),
             Schema::CAC.        'OrderLineReference'          => fn ($reader) => OrderLineReference::xmlDeserialize($reader),
             Schema::CAC.        'OrderReference'              => fn ($reader) => OrderReference::xmlDeserialize($reader),
+            Schema::CAC.        'OriginCountry'               => fn ($reader) => Country::xmlDeserialize($reader),
             Schema::CAC.        'Party'                       => fn ($reader) => Party::xmlDeserialize($reader),
             Schema::CAC.        'PartyLegalEntity'            => fn ($reader) => LegalEntity::xmlDeserialize($reader),
             Schema::CAC.        'PartyTaxScheme'              => fn ($reader) => PartyTaxScheme::xmlDeserialize($reader),

--- a/tests/Read/ItemOriginCountryTest.php
+++ b/tests/Read/ItemOriginCountryTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace NumNum\UBL\Tests\Read;
+
+use NumNum\UBL\Country;
+use NumNum\UBL\Invoice;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test reading Item with OriginCountry
+ */
+class ItemOriginCountryTest extends TestCase
+{
+    /** @test */
+    public function testItemOriginCountryCanBeRead()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:ID>12345</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Supplier</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Test Product</cbc:Name>
+            <cac:OriginCountry>
+                <cbc:IdentificationCode>CN</cbc:IdentificationCode>
+            </cac:OriginCountry>
+        </cac:Item>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = \NumNum\UBL\Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        $invoiceLines = $invoice->getInvoiceLines();
+        $this->assertNotEmpty($invoiceLines);
+
+        $firstLine = array_values($invoiceLines)[0];
+        $item = $firstLine->getItem();
+        $this->assertNotNull($item);
+
+        $originCountry = $item->getOriginCountry();
+        $this->assertNotNull($originCountry);
+        $this->assertInstanceOf(Country::class, $originCountry);
+        $this->assertEquals('CN', $originCountry->getIdentificationCode());
+    }
+
+    /** @test */
+    public function testItemWithoutOriginCountryCanBeRead()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:ID>12345</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Supplier</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Test Product</cbc:Name>
+        </cac:Item>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = \NumNum\UBL\Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        $invoiceLines = $invoice->getInvoiceLines();
+        $this->assertNotEmpty($invoiceLines);
+
+        $firstLine = array_values($invoiceLines)[0];
+        $item = $firstLine->getItem();
+        $this->assertNotNull($item);
+
+        // OriginCountry should be null when not present in XML
+        $originCountry = $item->getOriginCountry();
+        $this->assertNull($originCountry);
+    }
+}
+

--- a/tests/Write/ItemOriginCountryTest.php
+++ b/tests/Write/ItemOriginCountryTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace NumNum\UBL\Tests\Write;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Item with OriginCountry
+ */
+class ItemOriginCountryTest extends TestCase
+{
+    private $schema = 'http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd';
+
+    /** @test */
+    public function testItemWithOriginCountryIsValid()
+    {
+        // Address country
+        $country = (new \NumNum\UBL\Country())
+            ->setIdentificationCode('BE');
+
+        // Full address
+        $address = (new \NumNum\UBL\Address())
+            ->setStreetName('Korenmarkt')
+            ->setBuildingNumber(1)
+            ->setCityName('Gent')
+            ->setPostalZone('9000')
+            ->setCountry($country);
+
+        // Supplier company node
+        $supplierCompany = (new \NumNum\UBL\Party())
+            ->setName('Supplier Company Name')
+            ->setPhysicalLocation($address)
+            ->setPostalAddress($address);
+
+        // Client company node
+        $clientCompany = (new \NumNum\UBL\Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new \NumNum\UBL\LegalMonetaryTotal())
+            ->setPayableAmount(10 + 2)
+            ->setAllowanceTotalAmount(0);
+
+        // Tax scheme
+        $taxScheme = (new \NumNum\UBL\TaxScheme())
+            ->setId(0);
+
+        // Origin country for the product
+        $originCountry = (new \NumNum\UBL\Country())
+            ->setIdentificationCode('CN');
+
+        // Product with OriginCountry
+        $productItem = (new \NumNum\UBL\Item())
+            ->setName('Product Name')
+            ->setDescription('Product Description')
+            ->setSellersItemIdentification('SELLERID')
+            ->setOriginCountry($originCountry);
+
+        // Price
+        $price = (new \NumNum\UBL\Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(\NumNum\UBL\UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line tax totals
+        $lineTaxTotal = (new \NumNum\UBL\TaxTotal())
+            ->setTaxAmount(2.1);
+
+        // Invoice Line(s)
+        $invoiceLines = [];
+
+        $invoiceLines[] = (new \NumNum\UBL\InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setTaxTotal($lineTaxTotal)
+            ->setInvoicedQuantity(1);
+
+        // Total Taxes
+        $taxCategory = (new \NumNum\UBL\TaxCategory())
+            ->setId(0)
+            ->setName('VAT21%')
+            ->setPercent(.21)
+            ->setTaxScheme($taxScheme);
+
+        $taxSubTotal = (new \NumNum\UBL\TaxSubTotal())
+            ->setTaxableAmount(10)
+            ->setTaxAmount(2.1)
+            ->setTaxCategory($taxCategory);
+
+        $taxTotal = (new \NumNum\UBL\TaxTotal())
+            ->addTaxSubTotal($taxSubTotal)
+            ->setTaxAmount(2.1);
+
+        $accountingSupplierParty = (new \NumNum\UBL\AccountingParty())
+            ->setParty($supplierCompany);
+
+        $accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
+            ->setSupplierAssignedAccountId('10001')
+            ->setParty($clientCompany);
+
+        // Invoice object
+        $invoice = (new \NumNum\UBL\Invoice())
+            ->setId(1234)
+            ->setCopyIndicator(false)
+            ->setIssueDate(new \DateTime())
+            ->setAccountingSupplierParty($accountingSupplierParty)
+            ->setAccountingCustomerParty($accountingCustomerParty)
+            ->setInvoiceLines($invoiceLines)
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setTaxTotal($taxTotal);
+
+        // Test created object
+        // Use \NumNum\UBL\Generator to generate an XML string
+        $generator = new \NumNum\UBL\Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        // Verify that the OriginCountry element is present in the XML
+        $this->assertStringContainsString('<cac:OriginCountry>', $outputXMLString);
+        $this->assertStringContainsString('<cbc:IdentificationCode>CN</cbc:IdentificationCode>', $outputXMLString);
+
+        // Create PHP Native DomDocument object, that can be
+        // used to validate the generated XML
+        $dom = new \DOMDocument();
+        $dom->loadXML($outputXMLString);
+
+        $dom->save('./tests/ItemOriginCountryTest.xml');
+
+        $this->assertEquals(true, $dom->schemaValidate($this->schema));
+    }
+}
+


### PR DESCRIPTION
Adds support for `<cac:OriginCountry>` elements in `Item`.

Changes:
- New `originCountry` property on Item

Usage:
```php
$item = (new Item())
    ->setOriginCountry((new Country())->setIdentificationCode('DK'));
```