### PR TITLE
Add DespatchDocumentReference support to Invoice class

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -1,0 +1,9 @@
+# Changelog for next release
+
+### New features & improvements
+
+- Add `DespatchDocumentReference` support to `Invoice`
+  - New `DespatchDocumentReference` class with `id` property
+  - Added `getDespatchDocumentReference()` / `setDespatchDocumentReference()` methods to `Invoice`
+  - Full support for XML serialization and deserialization
+

--- a/src/DespatchDocumentReference.php
+++ b/src/DespatchDocumentReference.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace NumNum\UBL;
+
+use function Sabre\Xml\Deserializer\keyValue;
+
+use Sabre\Xml\Reader;
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlDeserializable;
+use Sabre\Xml\XmlSerializable;
+
+class DespatchDocumentReference implements XmlSerializable, XmlDeserializable
+{
+    private $id;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return static
+     */
+    public function setId(string $id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer): void
+    {
+        if ($this->id !== null) {
+            $writer->write([ Schema::CBC . 'ID' => $this->id ]);
+        }
+    }
+
+    /**
+     * The xmlDeserialize method is called during xml reading.
+     * @param Reader $xml
+     * @return static
+     */
+    public static function xmlDeserialize(Reader $reader)
+    {
+        $mixedContent = keyValue($reader);
+
+        return (new static())
+            ->setId($mixedContent[Schema::CBC . 'ID'] ?? null)
+        ;
+    }
+}

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -47,6 +47,7 @@ class Invoice implements XmlSerializable, XmlDeserializable
     private $delivery;
     private $orderReference;
     private $contractDocumentReference;
+    private $despatchDocumentReference;
 
     /**
      * @return string
@@ -626,6 +627,24 @@ class Invoice implements XmlSerializable, XmlDeserializable
     }
 
     /**
+     * @return DespatchDocumentReference
+     */
+    public function getDespatchDocumentReference(): ?DespatchDocumentReference
+    {
+        return $this->despatchDocumentReference;
+    }
+
+    /**
+     * @param DespatchDocumentReference $despatchDocumentReference
+     * @return static
+     */
+    public function setDespatchDocumentReference(?DespatchDocumentReference $despatchDocumentReference): static
+    {
+        $this->despatchDocumentReference = $despatchDocumentReference;
+        return $this;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @return void
@@ -751,6 +770,12 @@ class Invoice implements XmlSerializable, XmlDeserializable
         if ($this->billingReference != null) {
             $writer->write([
                 Schema::CAC . 'BillingReference' => $this->billingReference
+            ]);
+        }
+
+        if ($this->despatchDocumentReference !== null) {
+            $writer->write([
+                Schema::CAC . 'DespatchDocumentReference' => $this->despatchDocumentReference,
             ]);
         }
 
@@ -886,6 +911,7 @@ class Invoice implements XmlSerializable, XmlDeserializable
             ->setBillingReference(ReaderHelper::getTagValue(Schema::CAC . 'BillingReference', $collection))
             ->setDelivery(ReaderHelper::getTagValue(Schema::CAC . 'Delivery', $collection))
             ->setOrderReference(ReaderHelper::getTagValue(Schema::CAC . 'OrderReference', $collection))
-            ->setContractDocumentReference(ReaderHelper::getTagValue(Schema::CAC . 'ContractDocumentReference', $collection));
+            ->setContractDocumentReference(ReaderHelper::getTagValue(Schema::CAC . 'ContractDocumentReference', $collection))
+            ->setDespatchDocumentReference(ReaderHelper::getTagValue(Schema::CAC . 'DespatchDocumentReference', $collection));
     }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -35,6 +35,7 @@ class Reader
             Schema::CAC.        'Contact'                     => fn ($reader) => Contact::xmlDeserialize($reader),
             Schema::CAC.        'ContractDocumentReference'   => fn ($reader) => ContractDocumentReference::xmlDeserialize($reader),
             Schema::CAC.        'Country'                     => fn ($reader) => Country::xmlDeserialize($reader),
+            Schema::CAC.        'DespatchDocumentReference'   => fn ($reader) => DespatchDocumentReference::xmlDeserialize($reader),
             Schema::CAC.        'CreditNoteLine'              => fn ($reader) => CreditNoteLine::xmlDeserialize($reader),
             Schema::CAC.        'CreditNoteLine'              => fn ($reader) => CreditNoteLine::xmlDeserialize($reader),
             Schema::CAC.        'Delivery'                    => fn ($reader) => Delivery::xmlDeserialize($reader),

--- a/tests/Files/DespatchDocumentReferenceTest.xml
+++ b/tests/Files/DespatchDocumentReferenceTest.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+ <cbc:UBLVersionID>2.2</cbc:UBLVersionID>
+ <cbc:CustomizationID>1.0</cbc:CustomizationID>
+ <cbc:ID>1234</cbc:ID>
+ <cbc:CopyIndicator>false</cbc:CopyIndicator>
+ <cbc:IssueDate>2025-12-04</cbc:IssueDate>
+ <cbc:DueDate>2025-12-04</cbc:DueDate>
+ <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+ <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+ <cbc:BuyerReference>SomeReference</cbc:BuyerReference>
+ <cac:DespatchDocumentReference>
+  <cbc:ID>DESP-2024-001</cbc:ID>
+ </cac:DespatchDocumentReference>
+ <cac:AccountingSupplierParty>
+  <cac:Party>
+   <cac:PartyName>
+    <cbc:Name>Supplier Company Name</cbc:Name>
+   </cac:PartyName>
+   <cac:PostalAddress>
+    <cbc:StreetName>Korenmarkt</cbc:StreetName>
+    <cbc:BuildingNumber>1</cbc:BuildingNumber>
+    <cbc:CityName>Gent</cbc:CityName>
+    <cbc:PostalZone>9000</cbc:PostalZone>
+    <cac:Country>
+     <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+    </cac:Country>
+   </cac:PostalAddress>
+   <cac:PhysicalLocation>
+    <cac:Address>
+     <cbc:StreetName>Korenmarkt</cbc:StreetName>
+     <cbc:BuildingNumber>1</cbc:BuildingNumber>
+     <cbc:CityName>Gent</cbc:CityName>
+     <cbc:PostalZone>9000</cbc:PostalZone>
+     <cac:Country>
+      <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+     </cac:Country>
+    </cac:Address>
+   </cac:PhysicalLocation>
+  </cac:Party>
+ </cac:AccountingSupplierParty>
+ <cac:AccountingCustomerParty>
+  <cac:Party>
+   <cac:PartyName>
+    <cbc:Name>My client</cbc:Name>
+   </cac:PartyName>
+   <cac:PostalAddress>
+    <cbc:StreetName>Korenmarkt</cbc:StreetName>
+    <cbc:BuildingNumber>1</cbc:BuildingNumber>
+    <cbc:CityName>Gent</cbc:CityName>
+    <cbc:PostalZone>9000</cbc:PostalZone>
+    <cac:Country>
+     <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+    </cac:Country>
+   </cac:PostalAddress>
+  </cac:Party>
+ </cac:AccountingCustomerParty>
+ <cac:TaxTotal>
+  <cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
+  <cac:TaxSubtotal>
+   <cbc:TaxableAmount currencyID="EUR">10.00</cbc:TaxableAmount>
+   <cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
+   <cac:TaxCategory>
+    <cbc:ID schemeID="UNCL5305" schemeName="Duty or tax or fee category">S</cbc:ID>
+    <cbc:Name>VAT21%</cbc:Name>
+    <cbc:Percent>0.21</cbc:Percent>
+    <cac:TaxScheme>
+     <cbc:ID>0</cbc:ID>
+    </cac:TaxScheme>
+   </cac:TaxCategory>
+  </cac:TaxSubtotal>
+ </cac:TaxTotal>
+ <cac:LegalMonetaryTotal>
+  <cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+  <cbc:TaxExclusiveAmount currencyID="EUR">0.00</cbc:TaxExclusiveAmount>
+  <cbc:TaxInclusiveAmount currencyID="EUR">0.00</cbc:TaxInclusiveAmount>
+  <cbc:AllowanceTotalAmount currencyID="EUR">0.00</cbc:AllowanceTotalAmount>
+  <cbc:ChargeTotalAmount currencyID="EUR">0.00</cbc:ChargeTotalAmount>
+  <cbc:PayableAmount currencyID="EUR">12.00</cbc:PayableAmount>
+ </cac:LegalMonetaryTotal>
+ <cac:InvoiceLine>
+  <cbc:ID>0</cbc:ID>
+  <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+  <cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+  <cac:TaxTotal>
+   <cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:Item>
+   <cbc:Description>Product Description</cbc:Description>
+   <cbc:Name>Product Name</cbc:Name>
+  </cac:Item>
+  <cac:Price>
+   <cbc:PriceAmount currencyID="EUR">10</cbc:PriceAmount>
+   <cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+  </cac:Price>
+ </cac:InvoiceLine>
+</Invoice>

--- a/tests/Read/DespatchDocumentReferenceTest.php
+++ b/tests/Read/DespatchDocumentReferenceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NumNum\UBL\Tests\Read;
+
+use NumNum\UBL\DespatchDocumentReference;
+use NumNum\UBL\Invoice;
+use PHPUnit\Framework\TestCase;
+
+class DespatchDocumentReferenceTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testDespatchDocumentReferenceCanBeRead()
+    {
+        $ublReader = \NumNum\UBL\Reader::ubl();
+
+        $invoice = $ublReader->parse(file_get_contents(dirname(__DIR__).'/Files/DespatchDocumentReferenceTest.xml'));
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        $despatchDocumentReference = $invoice->getDespatchDocumentReference();
+        $this->assertNotNull($despatchDocumentReference);
+        $this->assertInstanceOf(DespatchDocumentReference::class, $despatchDocumentReference);
+        $this->assertEquals('DESP-2024-001', $despatchDocumentReference->getId());
+    }
+}
+

--- a/tests/Write/DespatchDocumentReferenceTest.php
+++ b/tests/Write/DespatchDocumentReferenceTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace NumNum\UBL\Tests\Write;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test DespatchDocumentReference in UBL2.2 invoice document
+ */
+class DespatchDocumentReferenceTest extends TestCase
+{
+    private $schema = 'http://docs.oasis-open.org/ubl/os-UBL-2.2/xsd/maindoc/UBL-Invoice-2.2.xsd';
+
+    /** @test */
+    public function testIfXMLIsValid()
+    {
+        // Address country
+        $country = (new \NumNum\UBL\Country())
+            ->setIdentificationCode('BE');
+
+        // Full address
+        $address = (new \NumNum\UBL\Address())
+            ->setStreetName('Korenmarkt')
+            ->setBuildingNumber(1)
+            ->setCityName('Gent')
+            ->setPostalZone('9000')
+            ->setCountry($country);
+
+        // Supplier company node
+        $supplierCompany = (new \NumNum\UBL\Party())
+            ->setName('Supplier Company Name')
+            ->setPhysicalLocation($address)
+            ->setPostalAddress($address);
+
+        // Client company node
+        $clientCompany = (new \NumNum\UBL\Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new \NumNum\UBL\LegalMonetaryTotal())
+            ->setPayableAmount(10 + 2)
+            ->setAllowanceTotalAmount(0);
+
+        // Tax scheme
+        $taxScheme = (new \NumNum\UBL\TaxScheme())
+            ->setId(0);
+
+        // Product
+        $productItem = (new \NumNum\UBL\Item())
+            ->setName('Product Name')
+            ->setDescription('Product Description');
+
+        // Price
+        $price = (new \NumNum\UBL\Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(\NumNum\UBL\UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line tax totals
+        $lineTaxTotal = (new \NumNum\UBL\TaxTotal())
+            ->setTaxAmount(2.1);
+
+        // Invoice Line(s)
+        $invoiceLine = (new \NumNum\UBL\InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setTaxTotal($lineTaxTotal)
+            ->setInvoicedQuantity(1);
+
+        $invoiceLines = [$invoiceLine];
+
+        // Total Taxes
+        $taxCategory = (new \NumNum\UBL\TaxCategory())
+            ->setId(0)
+            ->setName('VAT21%')
+            ->setPercent(.21)
+            ->setTaxScheme($taxScheme);
+
+        $taxSubTotal = (new \NumNum\UBL\TaxSubTotal())
+            ->setTaxableAmount(10)
+            ->setTaxAmount(2.1)
+            ->setTaxCategory($taxCategory);
+
+        $taxTotal = (new \NumNum\UBL\TaxTotal())
+            ->addTaxSubTotal($taxSubTotal)
+            ->setTaxAmount(2.1);
+
+        $despatchDocumentReference = (new \NumNum\UBL\DespatchDocumentReference())
+            ->setId("DESP-2024-001");
+
+        $accountingSupplierParty = (new \NumNum\UBL\AccountingParty())
+            ->setParty($supplierCompany);
+
+        $accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
+            ->setParty($clientCompany);
+
+        // Invoice object
+        $invoice = (new \NumNum\UBL\Invoice())
+            ->setUBLVersionId('2.2')
+            ->setId(1234)
+            ->setCopyIndicator(false)
+            ->setIssueDate(new \DateTime())
+            ->setInvoiceTypeCode(\NumNum\UBL\InvoiceTypeCode::INVOICE)
+            ->setDueDate(new \DateTime())
+            ->setAccountingSupplierParty($accountingSupplierParty)
+            ->setAccountingCustomerParty($accountingCustomerParty)
+            ->setInvoiceLines($invoiceLines)
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setTaxTotal($taxTotal)
+            ->setDespatchDocumentReference($despatchDocumentReference)
+            ->setBuyerReference("SomeReference");
+
+        // Test created object
+        // Use \NumNum\UBL\Generator to generate an XML string
+        $generator = new \NumNum\UBL\Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        // Create PHP Native DomDocument object, that can be
+        // used to validate the generate XML
+        $dom = new \DOMDocument();
+        $dom->loadXML($outputXMLString);
+
+        $this->assertEquals(true, $dom->schemaValidate($this->schema));
+    }
+
+    /** @test */
+    public function testDespatchDocumentReferenceIsInOutput()
+    {
+        // Address country
+        $country = (new \NumNum\UBL\Country())
+            ->setIdentificationCode('BE');
+
+        // Full address
+        $address = (new \NumNum\UBL\Address())
+            ->setStreetName('Korenmarkt')
+            ->setBuildingNumber(1)
+            ->setCityName('Gent')
+            ->setPostalZone('9000')
+            ->setCountry($country);
+
+        // Supplier company node
+        $supplierCompany = (new \NumNum\UBL\Party())
+            ->setName('Supplier Company Name')
+            ->setPostalAddress($address);
+
+        // Client company node
+        $clientCompany = (new \NumNum\UBL\Party())
+            ->setName('My client')
+            ->setPostalAddress($address);
+
+        $legalMonetaryTotal = (new \NumNum\UBL\LegalMonetaryTotal())
+            ->setPayableAmount(12);
+
+        // Product
+        $productItem = (new \NumNum\UBL\Item())
+            ->setName('Product Name');
+
+        // Price
+        $price = (new \NumNum\UBL\Price())
+            ->setBaseQuantity(1)
+            ->setUnitCode(\NumNum\UBL\UnitCode::UNIT)
+            ->setPriceAmount(10);
+
+        // Invoice Line(s)
+        $invoiceLine = (new \NumNum\UBL\InvoiceLine())
+            ->setId(0)
+            ->setItem($productItem)
+            ->setPrice($price)
+            ->setInvoicedQuantity(1);
+
+        $despatchDocumentReference = (new \NumNum\UBL\DespatchDocumentReference())
+            ->setId("DESP-2024-001");
+
+        $accountingSupplierParty = (new \NumNum\UBL\AccountingParty())
+            ->setParty($supplierCompany);
+
+        $accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
+            ->setParty($clientCompany);
+
+        // Invoice object
+        $invoice = (new \NumNum\UBL\Invoice())
+            ->setId(1234)
+            ->setIssueDate(new \DateTime())
+            ->setAccountingSupplierParty($accountingSupplierParty)
+            ->setAccountingCustomerParty($accountingCustomerParty)
+            ->setInvoiceLines([$invoiceLine])
+            ->setLegalMonetaryTotal($legalMonetaryTotal)
+            ->setDespatchDocumentReference($despatchDocumentReference);
+
+        $generator = new \NumNum\UBL\Generator();
+        $outputXMLString = $generator->invoice($invoice);
+
+        $this->assertStringContainsString('<cac:DespatchDocumentReference>', $outputXMLString);
+        $this->assertStringContainsString('<cbc:ID>DESP-2024-001</cbc:ID>', $outputXMLString);
+    }
+}
+


### PR DESCRIPTION
Adds support for `<cac:DespatchDocumentReference>` element in `Invoice`.

Changes:
- New `DespatchDocumentReference` class with `id` property
- Added `getDespatchDocumentReference()` / `setDespatchDocumentReference()` methods to `Invoice`

Usage:
```php
$despatchDocumentReference = (new \NumNum\UBL\DespatchDocumentReference())
    ->setId("DESP-2024-001");

$invoice = (new Invoice())
    ->setDespatchDocumentReference($despatchDocumentReference);
```