### PR TITLE
Add gitignore entries for AI agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,19 @@ $RECYCLE.BIN/
 
 # Editors
 .vscode/
+.phpactor.json
+
+## AI Agents
+.claude/
+.cursor/
+.cursorignore
+.cursorrules
+.aider*
+.continue/
+.codeium/
+.windsurf/
+.amazonq/
+.tabnine/
+.cody/
+.supermaven/
+.codex/


### PR DESCRIPTION
## Summary
- Add gitignore entries for common AI coding assistant configuration directories
- Includes: Claude Code, Cursor, Aider, Continue, Codeium, Windsurf, Amazon Q, Tabnine, Cody, Supermaven, Codex
- Also adds `.phpactor.json` to the Editors section

## Test plan
- [x] Verify `.gitignore` syntax is correct
- [x] Confirm AI agent directories are properly ignored