### PR TITLE
Fix PHP 7.4 compatibility: remove union types in AllowanceCharge

### DIFF
--- a/src/AllowanceCharge.php
+++ b/src/AllowanceCharge.php
@@ -42,7 +42,7 @@ class AllowanceCharge implements XmlSerializable, XmlDeserializable
     /**
      * @return int|string|null
      */
-    public function getAllowanceChargeReasonCode(): int|string|null
+    public function getAllowanceChargeReasonCode()
     {
         return $this->allowanceChargeReasonCode;
     }
@@ -51,7 +51,7 @@ class AllowanceCharge implements XmlSerializable, XmlDeserializable
      * @param int|string|null $allowanceChargeReasonCode
      * @return static
      */
-    public function setAllowanceChargeReasonCode(int|string|null $allowanceChargeReasonCode)
+    public function setAllowanceChargeReasonCode($allowanceChargeReasonCode)
     {
         $this->allowanceChargeReasonCode = $allowanceChargeReasonCode;
         return $this;
@@ -235,7 +235,7 @@ class AllowanceCharge implements XmlSerializable, XmlDeserializable
      * @param string|null $value
      * @return int|string|null
      */
-    private static function parseAllowanceChargeReasonCode(?string $value): int|string|null
+    private static function parseAllowanceChargeReasonCode(?string $value)
     {
         if ($value === null) {
             return null;


### PR DESCRIPTION
## Summary
- Remove union type declarations (`int|string|null`) from `AllowanceCharge.php` which are PHP 8.0+ only syntax
- Affected methods: `getAllowanceChargeReasonCode()`, `setAllowanceChargeReasonCode()`, `parseAllowanceChargeReasonCode()`
- Type information is preserved in docblocks for IDE support

This fixes PHP 7.4 compatibility that was broken since 2.0.0-beta14.

## Test plan
- [x] CI tests pass on PHP 7.4
- [x] CI tests pass on PHP 8.x versions