### PR TITLE
Prepare documentation for 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,5 @@
-# Changelog for v2.0.0-beta
+# Changelog
 
-### New features & improvements
+Since version 2.0, all changelog information can be found on the [GitHub Releases](https://github.com/num-num/ubl-invoice/releases) page.
 
-- Possibility to deserialize XML into object tree
-- Add `xmlDeserialize` support for `CreditNote` class to properly parse `<cac:CreditNoteLine>` elements - Thanks [@RoanB](https://github.com/RoanB)
-- Add `<cac:DespatchDocumentReference>` to `<Invoice>` - Thanks [@fMads](https://github.com/fMads)
-- Add `<cac:ReceiptDocumentReference>` to `<Invoice>`
-- Add `<cac:OriginatorDocumentReference>` to `<Invoice>`
-- Add FRCTC Electronic Address (0225) to EASCode - Thanks [@UbiManu](https://github.com/UbiManu)
-- Add `<cac:AddressLine>` support to `<cac:Address>` for additional unstructured address lines - Thanks [@fMads](https://github.com/fMads)
-- Add `<cac:OriginCountry>` support to `<cac:Item>` for specifying country of origin - Thanks [@fMads](https://github.com/fMads)
-- Update `AllowanceCharge::allowanceChargeReasonCode` to accept `int|string|null` instead of `?int`, allowing string values like "ZZZ" per UNCL7161 - Thanks [@Mikael-Leger](https://github.com/Mikael-Leger)
-
-### Bug fixes
-
-- Fix `Attachment::xmlSerialize()` to not output `EmbeddedDocumentBinaryObject` when only `externalReference` is set - Thanks [@fMads](https://github.com/fMads)
-
-### Maintenance
-
-- Update dependency constraints to support Carbon 3.x and Doctrine Collections 2.x - Thanks [@GHuygen](https://github.com/GHuygen)
-
-### Breaking changes
-
-- `Invoice::setAccountingSupplierParty` now requires an `AccountingParty` instead of a `Party` object
-- `Invoice::setAccountingCustomerParty` now requires an `AccountingParty` instead of a `Party` object
-- `Invoice::getAccountingSupplierParty` now returns an `AccountingParty` instead of a `Party` object
-- `Invoice::getAccountingCustomerParty` now returns an `AccountingParty` instead of a `Party` object
-- `Invoice::accountingCustomerPartyContact` has been removed, use `Invoice::getAccountingCustomerParty()->setAccountingContact()` instead
-- `Invoice::setSupplierAssignedAccountID`/`Invoice::getSupplierAssignedAccountID` no longer exists and has moved to `AccountingParty::setSupplierAssignedAccountID`/`AccountingParty::getSupplierAssignedAccountID`
-- `Attachment::setFileStream` / `Attachment::getFileStream` to manually set the Attachment xml tag base 64 string content, has been renamed to `Attachment::setBase64Content` / `Attachment::getBase64Content`
-- Functions `setUBLVersionID`/`getUBLVersionID` have been renamed to `setUBLVersionId`/`getUBLVersionId`
-- Functions `setSupplierAssignedAccountID`/`getSupplierAssignedAccountID` have been renamed to `setSupplierAssignedAccountId`/`getSupplierAssignedAccountId`
-- Functions `setUnitCodeListID`/`getUnitCodeListID` have been renamed to `setUnitCodeListId`/`getUnitCodeListId`
-- Functions `setSchemeID`/`getSchemeID` have been renamed to `setSchemeId`/`getSchemeId`
-- Functions `setCustomizationID`/`getCustomizationID` have been renamed to `setCustomizationId`/`getCustomizationId`
-- Functions `setProfileID`/`getProfileID` have been renamed to `setProfileId`/`getProfileId`
+For historical changelog entries (v1.x), please check the git history or older releases.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A modern object-oriented PHP library to **create** and **read** valid UBL and Pe
 
 This package is fully compatible with **PHP 8.x** and also supports **PHP 7.4**. You can install it using [Composer](https://www.getcomposer.org).
 ```zsh
-$ composer require num-num/ubl-invoice:^2.0@beta
+$ composer require num-num/ubl-invoice
 ```
 
 #### Creating UBL files
@@ -41,106 +41,9 @@ var_dump($invoice); // An \NumNum\UBL\Invoice instance with filled properties!
 
 Please check some additional example code in the `tests/Read` folder.
 
-## Upgrading from package version 1.0 to 2.0
+## Upgrading
 
-Version 2.0 of this package offers the ability to read UBL xml files and convert them into a `\NumNum\UBL\Invoice` or `\NumNum\UBL\CreditNote` + properties object structure.
-
-To upgrade from 1.0, there are a few small, but breaking changes that need to be considered.
-
-### New `AccountingParty` wrapper class
-
-The most significant change is that `setAccountingSupplierParty()` and `setAccountingCustomerParty()` now require an `AccountingParty` object instead of a `Party` object directly.
-
-**Before (v1.x):**
-```php
-$supplierParty = (new \NumNum\UBL\Party())
-    ->setName('Supplier Company Name')
-    ->setPostalAddress($address);
-
-$clientParty = (new \NumNum\UBL\Party())
-    ->setName('My client')
-    ->setPostalAddress($address);
-
-$invoice = (new \NumNum\UBL\Invoice())
-    ->setAccountingSupplierParty($supplierParty)
-    ->setAccountingCustomerParty($clientParty)
-    ->setSupplierAssignedAccountID('10001'); // Was on Invoice
-```
-
-**After (v2.0):**
-```php
-$supplierParty = (new \NumNum\UBL\Party())
-    ->setName('Supplier Company Name')
-    ->setPostalAddress($address);
-
-$clientParty = (new \NumNum\UBL\Party())
-    ->setName('My client')
-    ->setPostalAddress($address);
-
-// Wrap Party objects in AccountingParty
-$accountingSupplierParty = (new \NumNum\UBL\AccountingParty())
-    ->setParty($supplierParty);
-
-$accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
-    ->setParty($clientParty)
-    ->setSupplierAssignedAccountId('10001'); // Now on AccountingParty
-
-$invoice = (new \NumNum\UBL\Invoice())
-    ->setAccountingSupplierParty($accountingSupplierParty)
-    ->setAccountingCustomerParty($accountingCustomerParty);
-```
-
-### `accountingCustomerPartyContact` moved to `AccountingParty`
-
-If you were using `Invoice::accountingCustomerPartyContact`, use `AccountingParty::setAccountingContact()` instead:
-
-**Before (v1.x):**
-```php
-$invoice->accountingCustomerPartyContact($contact);
-```
-
-**After (v2.0):**
-```php
-$accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
-    ->setParty($clientParty)
-    ->setAccountingContact($contact);
-```
-
-### Attachment `setFileStream` renamed to `setBase64Content`
-
-**Before (v1.x):**
-```php
-$attachment->setFileStream($base64Content);
-$content = $attachment->getFileStream();
-```
-
-**After (v2.0):**
-```php
-$attachment->setBase64Content($base64Content);
-$content = $attachment->getBase64Content();
-```
-
-### Function naming consistency (ID → Id)
-
-All functions with `ID` suffix have been renamed to use `Id` for consistency:
-
-| Before (v1.x) | After (v2.0) |
-|---------------|--------------|
-| `setUBLVersionID()` / `getUBLVersionID()` | `setUBLVersionId()` / `getUBLVersionId()` |
-| `setCustomizationID()` / `getCustomizationID()` | `setCustomizationId()` / `getCustomizationId()` |
-| `setProfileID()` / `getProfileID()` | `setProfileId()` / `getProfileId()` |
-| `setSchemeID()` / `getSchemeID()` | `setSchemeId()` / `getSchemeId()` |
-| `setUnitCodeListID()` / `getUnitCodeListID()` | `setUnitCodeListId()` / `getUnitCodeListId()` |
-| `setSupplierAssignedAccountID()` / `getSupplierAssignedAccountID()` | `setSupplierAssignedAccountId()` / `getSupplierAssignedAccountId()` |
-
-### Quick migration checklist
-
-- [ ] Wrap `Party` objects in `AccountingParty` for supplier/customer parties
-- [ ] Move `setSupplierAssignedAccountID()` from `Invoice` to `AccountingParty` and rename to `setSupplierAssignedAccountId()`
-- [ ] Replace `accountingCustomerPartyContact()` with `AccountingParty::setAccountingContact()`
-- [ ] Rename `setFileStream()`/`getFileStream()` to `setBase64Content()`/`getBase64Content()` on Attachments
-- [ ] Update all `*ID()` method calls to use `*Id()` naming
-
+If you are upgrading from version 1.x to 2.0, please check the [UPGRADING.md](UPGRADING.md) guide for breaking changes and migration instructions.
 
 ## Contributing - bug reporting
 
@@ -156,4 +59,4 @@ This repository does not have a documentation website at this moment. For now, p
 
 ## Changelog
 
-A changelog is available since version v1.9.0. If you are upgrading a minor version (1.x) or major version, please check the changelog to see if you need to implement any breaking changes...
+Since version 2.0, all changelog information can be found on the [GitHub Releases](https://github.com/num-num/ubl-invoice/releases) page.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,101 @@
+# Upgrading Guide
+
+## Upgrading from package version 1.0 to 2.0
+
+Version 2.0 of this package offers the ability to read UBL xml files and convert them into a `\NumNum\UBL\Invoice` or `\NumNum\UBL\CreditNote` + properties object structure.
+
+To upgrade from 1.0, there are a few small, but breaking changes that need to be considered.
+
+### New `AccountingParty` wrapper class
+
+The most significant change is that `setAccountingSupplierParty()` and `setAccountingCustomerParty()` now require an `AccountingParty` object instead of a `Party` object directly.
+
+**Before (v1.x):**
+```php
+$supplierParty = (new \NumNum\UBL\Party())
+    ->setName('Supplier Company Name')
+    ->setPostalAddress($address);
+
+$clientParty = (new \NumNum\UBL\Party())
+    ->setName('My client')
+    ->setPostalAddress($address);
+
+$invoice = (new \NumNum\UBL\Invoice())
+    ->setAccountingSupplierParty($supplierParty)
+    ->setAccountingCustomerParty($clientParty)
+    ->setSupplierAssignedAccountID('10001'); // Was on Invoice
+```
+
+**After (v2.0):**
+```php
+$supplierParty = (new \NumNum\UBL\Party())
+    ->setName('Supplier Company Name')
+    ->setPostalAddress($address);
+
+$clientParty = (new \NumNum\UBL\Party())
+    ->setName('My client')
+    ->setPostalAddress($address);
+
+// Wrap Party objects in AccountingParty
+$accountingSupplierParty = (new \NumNum\UBL\AccountingParty())
+    ->setParty($supplierParty);
+
+$accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
+    ->setParty($clientParty)
+    ->setSupplierAssignedAccountId('10001'); // Now on AccountingParty
+
+$invoice = (new \NumNum\UBL\Invoice())
+    ->setAccountingSupplierParty($accountingSupplierParty)
+    ->setAccountingCustomerParty($accountingCustomerParty);
+```
+
+### `accountingCustomerPartyContact` moved to `AccountingParty`
+
+If you were using `Invoice::accountingCustomerPartyContact`, use `AccountingParty::setAccountingContact()` instead:
+
+**Before (v1.x):**
+```php
+$invoice->accountingCustomerPartyContact($contact);
+```
+
+**After (v2.0):**
+```php
+$accountingCustomerParty = (new \NumNum\UBL\AccountingParty())
+    ->setParty($clientParty)
+    ->setAccountingContact($contact);
+```
+
+### Attachment `setFileStream` renamed to `setBase64Content`
+
+**Before (v1.x):**
+```php
+$attachment->setFileStream($base64Content);
+$content = $attachment->getFileStream();
+```
+
+**After (v2.0):**
+```php
+$attachment->setBase64Content($base64Content);
+$content = $attachment->getBase64Content();
+```
+
+### Function naming consistency (ID → Id)
+
+All functions with `ID` suffix have been renamed to use `Id` for consistency:
+
+| Before (v1.x) | After (v2.0) |
+|---------------|--------------|
+| `setUBLVersionID()` / `getUBLVersionID()` | `setUBLVersionId()` / `getUBLVersionId()` |
+| `setCustomizationID()` / `getCustomizationID()` | `setCustomizationId()` / `getCustomizationId()` |
+| `setProfileID()` / `getProfileID()` | `setProfileId()` / `getProfileId()` |
+| `setSchemeID()` / `getSchemeID()` | `setSchemeId()` / `getSchemeId()` |
+| `setUnitCodeListID()` / `getUnitCodeListID()` | `setUnitCodeListId()` / `getUnitCodeListId()` |
+| `setSupplierAssignedAccountID()` / `getSupplierAssignedAccountID()` | `setSupplierAssignedAccountId()` / `getSupplierAssignedAccountId()` |
+
+### Quick migration checklist
+
+- [ ] Wrap `Party` objects in `AccountingParty` for supplier/customer parties
+- [ ] Move `setSupplierAssignedAccountID()` from `Invoice` to `AccountingParty` and rename to `setSupplierAssignedAccountId()`
+- [ ] Replace `accountingCustomerPartyContact()` with `AccountingParty::setAccountingContact()`
+- [ ] Rename `setFileStream()`/`getFileStream()` to `setBase64Content()`/`getBase64Content()` on Attachments
+- [ ] Update all `*ID()` method calls to use `*Id()` naming


### PR DESCRIPTION
## Summary

- Remove `:^2.0@beta` from composer install command
- Move upgrade guide from README.md to dedicated UPGRADING.md
- Update CHANGELOG.md to point to GitHub Releases page
- Add reference to UPGRADING.md in README.md

## Changes

| File | Description |
|------|-------------|
| `README.md` | Simplified install command, removed upgrade section, added link to UPGRADING.md |
| `UPGRADING.md` | New file with complete v1.x → v2.0 migration guide |
| `CHANGELOG.md` | Now redirects to GitHub Releases |
