### PR TITLE
Patch for consistency (ID → Id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - `Invoice::getAccountingSupplierParty` now returns an `AccountingParty` instead of a `Party` object
 - `Invoice::getAccountingCustomerParty` now returns an `AccountingParty` instead of a `Party` object
 - `Invoice::accountingCustomerPartyContact` has been removed, use `Invoice::getAccountingCustomerParty()->setAccountingContact()` instead
-- `Invoice::setSupplierAssignedAccountID`/`Invoice::getSupplierAssignedAccountID` no longer exists and has moved to `AccountingParty::setSupplierAssignedAccountID`/`AccountingParty::getSupplierAssignedAccountID`
+- `Invoice::setSupplierAssignedAccountID`/`Invoice::getSupplierAssignedAccountID` no longer exists and has moved and renamed to `AccountingParty::setSupplierAssignedAccountId`/`AccountingParty::getSupplierAssignedAccountId`
 - `Attachment::setFileStream` / `Attachment::getFileStream` to manually set the Attachment xml tag base 64 string content, has been renamed to `Attachment::setBase64Content` / `Attachment::getBase64Content`
 - Functions `setUBLVersionID`/`getUBLVersionID` have been renamed to `setUBLVersionId`/`getUBLVersionId`
 - Functions `setSupplierAssignedAccountID`/`getSupplierAssignedAccountID` have been renamed to `setSupplierAssignedAccountId`/`getSupplierAssignedAccountId`

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -273,25 +273,6 @@ class Invoice implements XmlSerializable, XmlDeserializable
     }
 
     /**
-     * @return string
-     */
-    public function getSupplierAssignedAccountID(): ?string
-    {
-        return $this->supplierAssignedAccountID;
-    }
-
-    /**
-     * @param string $supplierAssignedAccountID
-     * @return Invoice
-     */
-    public function setSupplierAssignedAccountID(
-        string $supplierAssignedAccountID
-    ): Invoice {
-        $this->supplierAssignedAccountID = $supplierAssignedAccountID;
-        return $this;
-    }
-
-    /**
      * @return AccountingParty
      */
     public function getAccountingCustomerParty(): ?AccountingParty


### PR DESCRIPTION
- Actually removed Invoice:: setSupplierAssignedAccountID/Invoice::getSupplierAssignedAccountID as described in the README.
- Updated CHANGELOG

Not 100% sure this change _needs_ to be merged, although tests are still running fine.