### PR TITLE
Remove old methods

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -273,25 +273,6 @@ class Invoice implements XmlSerializable, XmlDeserializable
     }
 
     /**
-     * @return string
-     */
-    public function getSupplierAssignedAccountID(): ?string
-    {
-        return $this->supplierAssignedAccountID;
-    }
-
-    /**
-     * @param string $supplierAssignedAccountID
-     * @return Invoice
-     */
-    public function setSupplierAssignedAccountID(
-        string $supplierAssignedAccountID
-    ): Invoice {
-        $this->supplierAssignedAccountID = $supplierAssignedAccountID;
-        return $this;
-    }
-
-    /**
      * @return AccountingParty
      */
     public function getAccountingCustomerParty(): ?AccountingParty


### PR DESCRIPTION
Removed Invoice::setSupplierAssignedAccountID and Invoice::getSupplierAssignedAccountID which are replaced by AccountingParty::setSupplierAssignedAccountId and AccountingParty::getSupplierAssignedAccountId