### PR TITLE
Fix TypeError: Change InvoiceTypeCode type from string to int

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -181,19 +181,19 @@ class Invoice implements XmlSerializable, XmlDeserializable
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getInvoiceTypeCode(): ?string
+    public function getInvoiceTypeCode(): ?int
     {
         return $this->invoiceTypeCode;
     }
 
     /**
-     * @param string $invoiceTypeCode
-     *                                See also: src/InvoiceTypeCode.php
+     * @param int $invoiceTypeCode
+     *                             See also: src/InvoiceTypeCode.php
      * @return static
      */
-    public function setInvoiceTypeCode(?string $invoiceTypeCode)
+    public function setInvoiceTypeCode(?int $invoiceTypeCode)
     {
         $this->invoiceTypeCode = $invoiceTypeCode;
         return $this;
@@ -1011,10 +1011,10 @@ class Invoice implements XmlSerializable, XmlDeserializable
                 ),
             )
             ->setInvoiceTypeCode(
-                ReaderHelper::getTagValue(
+                ($typeCode = ReaderHelper::getTagValue(
                     Schema::CBC . "InvoiceTypeCode",
                     $collection,
-                ),
+                )) !== null ? (int) $typeCode : null,
             )
             ->setNote(
                 ReaderHelper::getTagValue(Schema::CBC . "Note", $collection),


### PR DESCRIPTION
## Summary
- Changed `getInvoiceTypeCode()` return type from `?string` to `?int`
- Changed `setInvoiceTypeCode()` parameter type from `?string` to `?int`
- Updated `xmlDeserialize()` to cast XML string value to `int`

## Problem
The `InvoiceTypeCode` constants are defined as integers:
```php
public const INVOICE = 380;
public const CREDIT_NOTE = 381;
```

But `setInvoiceTypeCode()` expected a `?string`, causing a TypeError when using `declare(strict_types=1)`:
```php
$invoice->setInvoiceTypeCode(InvoiceTypeCode::INVOICE); // TypeError!
```

## Solution
Change the type hint to `?int` to match the actual constant types.

Fixes #96