### PR TITLE
Fix parsing of invoices with large embedded attachments

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -13,6 +13,7 @@ class Reader
         self::$currencyID = $currencyId;
 
         $xmlService = new Service();
+        $xmlService->options = LIBXML_PARSEHUGE;
 
         $xmlService->namespaceMap = [
             Schema::INVOICE => '',


### PR DESCRIPTION
## Summary
- Enables `LIBXML_PARSEHUGE` on the Sabre XML Service to support parsing UBL documents with large base64-encoded PDF attachments (>10MB)
- Without this flag, libxml throws `"huge text node"` errors when encountering large embedded binary objects

## Test plan
- [ ] Existing unit tests pass (`vendor/bin/phpunit`)
- [ ] UBL invoices with large embedded PDF attachments can now be parsed without exceptions