### PR TITLE
Fix AdditionalItemProperty hydration and declare ext-libxml requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
+        "ext-libxml": "*",
         "sabre/xml": "^4.0",
         "nesbot/carbon": "^2.72 || ^3.11",
         "doctrine/collections": "^1.8 || ^2.0"

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -902,10 +902,7 @@ class Invoice implements XmlSerializable, XmlDeserializable
         }
 
         if (!empty($this->additionalDocumentReferences)) {
-            foreach (
-                $this->additionalDocumentReferences
-                as $additionalDocumentReference
-            ) {
+            foreach ($this->additionalDocumentReferences as $additionalDocumentReference) {
                 $writer->write([
                     Schema::CAC .
                     "AdditionalDocumentReference" => $additionalDocumentReference,

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -28,6 +28,7 @@ class Reader
             Schema::CAC.        'AccountingCustomerParty'     => fn ($reader) => AccountingParty::xmlDeserialize($reader),
             Schema::CAC.        'AccountingSupplierParty'     => fn ($reader) => AccountingParty::xmlDeserialize($reader),
             Schema::CAC.        'AdditionalDocumentReference' => fn ($reader) => AdditionalDocumentReference::xmlDeserialize($reader),
+            Schema::CAC.        'AdditionalItemProperty'      => fn ($reader) => AdditionalItemProperty::xmlDeserialize($reader),
             Schema::CAC.        'Address'                     => fn ($reader) => Address::xmlDeserialize($reader),
             Schema::CAC.        'AddressLine'                 => fn ($reader) => AddressLine::xmlDeserialize($reader),
             Schema::CAC.        'AllowanceCharge'             => fn ($reader) => AllowanceCharge::xmlDeserialize($reader),

--- a/tests/Read/ItemAdditionalItemPropertyTest.php
+++ b/tests/Read/ItemAdditionalItemPropertyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace NumNum\UBL\Tests\Read;
+
+use NumNum\UBL\AdditionalItemProperty;
+use NumNum\UBL\Invoice;
+use NumNum\UBL\Reader;
+use PHPUnit\Framework\TestCase;
+
+class ItemAdditionalItemPropertyTest extends TestCase
+{
+    /** @test */
+    public function testAdditionalItemPropertiesAreHydratedAsObjects()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:ID>12345</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Supplier</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Test Product</cbc:Name>
+            <cac:AdditionalItemProperty>
+                <cbc:Name>Color</cbc:Name>
+                <cbc:Value>Blue</cbc:Value>
+            </cac:AdditionalItemProperty>
+        </cac:Item>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        $invoiceLines = $invoice->getInvoiceLines();
+        $this->assertNotEmpty($invoiceLines);
+
+        $firstLine = array_values($invoiceLines)[0];
+        $item = $firstLine->getItem();
+        $this->assertNotNull($item);
+
+        $additionalItemProperties = $item->getAdditionalItemProperties();
+        $this->assertIsArray($additionalItemProperties);
+        $this->assertCount(1, $additionalItemProperties);
+        $firstAdditionalItemProperty = reset($additionalItemProperties);
+        $this->assertInstanceOf(AdditionalItemProperty::class, $firstAdditionalItemProperty);
+        $this->assertEquals('Color', $firstAdditionalItemProperty->getName());
+        $this->assertEquals('Blue', $firstAdditionalItemProperty->getValue());
+    }
+}

--- a/tests/Read/ItemOriginCountryTest.php
+++ b/tests/Read/ItemOriginCountryTest.php
@@ -2,6 +2,7 @@
 
 namespace NumNum\UBL\Tests\Read;
 
+use NumNum\UBL\AdditionalItemProperty;
 use NumNum\UBL\Country;
 use NumNum\UBL\Invoice;
 use PHPUnit\Framework\TestCase;
@@ -132,5 +133,71 @@ XML;
         $originCountry = $item->getOriginCountry();
         $this->assertNull($originCountry);
     }
-}
 
+    /** @test */
+    public function testAdditionalItemPropertiesAreHydratedAsObjects()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:ID>12345</cbc:ID>
+    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Supplier</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Test Product</cbc:Name>
+            <cac:AdditionalItemProperty>
+                <cbc:Name>Color</cbc:Name>
+                <cbc:Value>Blue</cbc:Value>
+            </cac:AdditionalItemProperty>
+        </cac:Item>
+    </cac:InvoiceLine>
+</Invoice>
+XML;
+
+        $ublReader = \NumNum\UBL\Reader::ubl();
+        $invoice = $ublReader->parse($xml);
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoice::class, $invoice);
+
+        $invoiceLines = $invoice->getInvoiceLines();
+        $this->assertNotEmpty($invoiceLines);
+
+        $firstLine = array_values($invoiceLines)[0];
+        $item = $firstLine->getItem();
+        $this->assertNotNull($item);
+
+        $additionalItemProperties = $item->getAdditionalItemProperties();
+        $this->assertIsArray($additionalItemProperties);
+        $this->assertCount(1, $additionalItemProperties);
+        $firstAdditionalItemProperty = reset($additionalItemProperties);
+        $this->assertInstanceOf(AdditionalItemProperty::class, $firstAdditionalItemProperty);
+        $this->assertEquals('Color', $firstAdditionalItemProperty->getName());
+        $this->assertEquals('Blue', $firstAdditionalItemProperty->getValue());
+    }
+}

--- a/tests/Read/ItemOriginCountryTest.php
+++ b/tests/Read/ItemOriginCountryTest.php
@@ -2,7 +2,6 @@
 
 namespace NumNum\UBL\Tests\Read;
 
-use NumNum\UBL\AdditionalItemProperty;
 use NumNum\UBL\Country;
 use NumNum\UBL\Invoice;
 use PHPUnit\Framework\TestCase;
@@ -134,70 +133,4 @@ XML;
         $this->assertNull($originCountry);
     }
 
-    /** @test */
-    public function testAdditionalItemPropertiesAreHydratedAsObjects()
-    {
-        $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-    <cbc:ID>12345</cbc:ID>
-    <cbc:IssueDate>2024-01-01</cbc:IssueDate>
-    <cac:AccountingSupplierParty>
-        <cac:Party>
-            <cac:PartyName>
-                <cbc:Name>Supplier</cbc:Name>
-            </cac:PartyName>
-        </cac:Party>
-    </cac:AccountingSupplierParty>
-    <cac:AccountingCustomerParty>
-        <cac:Party>
-            <cac:PartyName>
-                <cbc:Name>Customer</cbc:Name>
-            </cac:PartyName>
-        </cac:Party>
-    </cac:AccountingCustomerParty>
-    <cac:TaxTotal>
-        <cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
-    </cac:TaxTotal>
-    <cac:LegalMonetaryTotal>
-        <cbc:PayableAmount currencyID="EUR">121.00</cbc:PayableAmount>
-    </cac:LegalMonetaryTotal>
-    <cac:InvoiceLine>
-        <cbc:ID>1</cbc:ID>
-        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
-        <cbc:LineExtensionAmount currencyID="EUR">100</cbc:LineExtensionAmount>
-        <cac:Item>
-            <cbc:Name>Test Product</cbc:Name>
-            <cac:AdditionalItemProperty>
-                <cbc:Name>Color</cbc:Name>
-                <cbc:Value>Blue</cbc:Value>
-            </cac:AdditionalItemProperty>
-        </cac:Item>
-    </cac:InvoiceLine>
-</Invoice>
-XML;
-
-        $ublReader = \NumNum\UBL\Reader::ubl();
-        $invoice = $ublReader->parse($xml);
-
-        $this->assertNotNull($invoice);
-        $this->assertInstanceOf(Invoice::class, $invoice);
-
-        $invoiceLines = $invoice->getInvoiceLines();
-        $this->assertNotEmpty($invoiceLines);
-
-        $firstLine = array_values($invoiceLines)[0];
-        $item = $firstLine->getItem();
-        $this->assertNotNull($item);
-
-        $additionalItemProperties = $item->getAdditionalItemProperties();
-        $this->assertIsArray($additionalItemProperties);
-        $this->assertCount(1, $additionalItemProperties);
-        $firstAdditionalItemProperty = reset($additionalItemProperties);
-        $this->assertInstanceOf(AdditionalItemProperty::class, $firstAdditionalItemProperty);
-        $this->assertEquals('Color', $firstAdditionalItemProperty->getName());
-        $this->assertEquals('Blue', $firstAdditionalItemProperty->getValue());
-    }
 }


### PR DESCRIPTION
This PR fixes an inconsistency in AdditionalItemProperty deserialization and makes a runtime dependency explicit.

Item::getAdditionalItemProperties() is documented as returning AdditionalItemProperty[], but during XML parsing it could return raw Sabre array structures instead of typed objects.
Root cause: cac:AdditionalItemProperty was missing from Reader::ubl() elementMap.
Additionally, the reader uses LIBXML_PARSEHUGE, but ext-libxml was not explicitly declared in composer.json.