### PR TITLE
Fix currencyID in PaymentTerms

### DIFF
--- a/src/PaymentTerms.php
+++ b/src/PaymentTerms.php
@@ -104,7 +104,7 @@ class PaymentTerms implements XmlSerializable, XmlDeserializable
                     'name'       => Schema::CBC . 'Amount',
                     'value'      => NumberFormatter::format($this->amount, 2),
                     'attributes' => [
-                        'currencyID' => 'EUR'
+                        'currencyID' => Generator::$currencyID
                     ]
                 ]
             ]);


### PR DESCRIPTION
The currencyID was hardcoded to 'EUR', it now uses Generator::$currencyID, same as it is done in other places.

Fixes #177