### PR TITLE
Fix NumberFormatter ignoring an explicit 0 decimals

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,11 @@
         </include>
     </coverage>
     <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+            <exclude>tests/Read</exclude>
+            <exclude>tests/Write</exclude>
+        </testsuite>
         <testsuite name="write">
             <directory>tests/Write</directory>
         </testsuite>

--- a/src/NumberFormatter.php
+++ b/src/NumberFormatter.php
@@ -19,7 +19,7 @@ class NumberFormatter
         string $decimalSeparator = ".",
         string $thousandsSeparator = ""
     ) {
-        if ($decimals == null) {
+        if ($decimals === null) {
             // Get the current decimal point character according to the locale
             // This is needed because (string)$number uses the locale's decimal separator
             $locale = localeconv();

--- a/tests/NumberFormatterTest.php
+++ b/tests/NumberFormatterTest.php
@@ -30,6 +30,13 @@ class NumberFormatterTest extends TestCase
             [1.236789,  '1.24',      2],
             [1,         '1.00',      2],
             [1.000,     '1',         null],
+
+            // An explicit 0 must round to a whole number, not fall back
+            // to auto-detecting the decimals present in the input
+            [12.345,    '12',        0],
+            [0.5,       '1',         0],
+            [1.0,       '1',         0],
+            [0.0,       '0',         0],
         ];
     }
 }


### PR DESCRIPTION
The check for the optional $decimals argument used a loose comparison, so an explicit 0 was treated the same as null and fell back to auto-detecting the decimals present in the input. NumberFormatter::format(12.345, 0) returned '12.345' instead of '12'.

The NumberFormatterTest was never executed: it sits at the root of tests/, while phpunit.xml only registered the tests/Write and tests/Read directories. Added a 'unit' testsuite covering the root so the new cases actually run.